### PR TITLE
Fix some build checks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,10 +1,6 @@
 # Only trigger when a PR is committed.
 name: Linux Build All Arches
-on:
-  pull_request:
-    types: [closed]
-#    branches:
-#      - master
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
-        sudo apt-get install mingw-w64-x86-64-dev gcc-mingw-w64-x86-64 gcc-mingw-w64
+        sudo apt-get install mingw-w64-x86-64-dev gcc-mingw-w64-x86-64 gcc-mingw-w64 libsystemd-dev
 
     - name: Use Node.js v12
       uses: actions/setup-node@v1


### PR DESCRIPTION
The Linux build checks only run when a PR is merged to the master branch, which is too late for us to see if something broke.