### PR TITLE
[RFC/WIP] User authentication HTML templates

### DIFF
--- a/api/authenticators/auth.go
+++ b/api/authenticators/auth.go
@@ -13,7 +13,7 @@ type Authenticator interface {
 	AddHandlers(config_obj *config_proto.Config, mux *http.ServeMux) error
 	AuthenticateUserHandler(
 		config_obj *config_proto.Config,
-		parent http.Handler) http.Handler
+		parent http.Handler) (http.Handler, error)
 
 	IsPasswordLess() bool
 }

--- a/api/authenticators/azure.go
+++ b/api/authenticators/azure.go
@@ -60,7 +60,7 @@ func (self *AzureAuthenticator) AddHandlers(config_obj *config_proto.Config, mux
 // Check that the user is proerly authenticated.
 func (self *AzureAuthenticator) AuthenticateUserHandler(
 	config_obj *config_proto.Config,
-	parent http.Handler) http.Handler {
+	parent http.Handler) (http.Handler, error) {
 
 	return authenticateUserHandle(
 		config_obj, parent, "/auth/azure/login", "Microsoft O365/Azure AD")

--- a/api/authenticators/azure.go
+++ b/api/authenticators/azure.go
@@ -53,8 +53,7 @@ func (self *AzureAuthenticator) AddHandlers(config_obj *config_proto.Config, mux
 	mux.Handle("/auth/azure/callback", oauthAzureCallback(config_obj))
 	mux.Handle("/auth/azure/picture", oauthAzurePicture(config_obj))
 
-	installLogoff(config_obj, mux)
-	return nil
+	return installLogoff(config_obj, mux)
 }
 
 // Check that the user is proerly authenticated.

--- a/api/authenticators/basic.go
+++ b/api/authenticators/basic.go
@@ -50,7 +50,7 @@ func (self *BasicAuthenticator) IsPasswordLess() bool {
 
 func (self *BasicAuthenticator) AuthenticateUserHandler(
 	config_obj *config_proto.Config,
-	parent http.Handler) http.Handler {
+	parent http.Handler) (http.Handler, error) {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-CSRF-Token", csrf.Token(r))
 		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
@@ -116,5 +116,5 @@ func (self *BasicAuthenticator) AuthenticateUserHandler(
 		// the USER value in the context.
 		GetLoggingHandler(config_obj)(parent).ServeHTTP(
 			w, r.WithContext(ctx))
-	})
+	}), nil
 }

--- a/api/authenticators/github.go
+++ b/api/authenticators/github.go
@@ -50,8 +50,7 @@ func (self *GitHubAuthenticator) AddHandlers(config_obj *config_proto.Config, mu
 	mux.Handle("/auth/github/login", oauthGithubLogin(config_obj))
 	mux.Handle("/auth/github/callback", oauthGithubCallback(config_obj))
 
-	installLogoff(config_obj, mux)
-	return nil
+	return installLogoff(config_obj, mux)
 }
 
 // Check that the user is proerly authenticated.

--- a/api/authenticators/github.go
+++ b/api/authenticators/github.go
@@ -57,7 +57,7 @@ func (self *GitHubAuthenticator) AddHandlers(config_obj *config_proto.Config, mu
 // Check that the user is proerly authenticated.
 func (self *GitHubAuthenticator) AuthenticateUserHandler(
 	config_obj *config_proto.Config,
-	parent http.Handler) http.Handler {
+	parent http.Handler) (http.Handler, error) {
 
 	return authenticateUserHandle(
 		config_obj, parent, "/auth/github/login", "GitHub")

--- a/api/authenticators/google.go
+++ b/api/authenticators/google.go
@@ -62,7 +62,7 @@ func (self *GoogleAuthenticator) IsPasswordLess() bool {
 // Check that the user is proerly authenticated.
 func (self *GoogleAuthenticator) AuthenticateUserHandler(
 	config_obj *config_proto.Config,
-	parent http.Handler) http.Handler {
+	parent http.Handler) (http.Handler, error) {
 
 	return authenticateUserHandle(
 		config_obj, parent, "/auth/google/login", "Google")
@@ -236,7 +236,7 @@ func installLogoff(config_obj *config_proto.Config, mux *http.ServeMux) {
 }
 
 func authenticateUserHandle(config_obj *config_proto.Config,
-	parent http.Handler, login_url string, provider string) http.Handler {
+	parent http.Handler, login_url string, provider string) (http.Handler, error) {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-CSRF-Token", csrf.Token(r))
@@ -361,5 +361,5 @@ to log in again:
 		// the contextKeyUser value in the context.
 		GetLoggingHandler(config_obj)(parent).ServeHTTP(
 			w, r.WithContext(ctx))
-	})
+	}), nil
 }

--- a/api/authenticators/oidc.go
+++ b/api/authenticators/oidc.go
@@ -45,7 +45,7 @@ func (*OidcAuthenticator) AddHandlers(config_obj *config_proto.Config, mux *http
 
 func (*OidcAuthenticator) AuthenticateUserHandler(
 	config_obj *config_proto.Config,
-	parent http.Handler) http.Handler {
+	parent http.Handler) (http.Handler, error) {
 	return authenticateUserHandle(
 		config_obj, parent, oidcLoginURI, "OIDC")
 }

--- a/api/authenticators/oidc.go
+++ b/api/authenticators/oidc.go
@@ -39,8 +39,7 @@ func (*OidcAuthenticator) AddHandlers(config_obj *config_proto.Config, mux *http
 	mux.Handle(oidcLoginURI, oauthOidcLogin(config_obj, provider))
 	mux.Handle(oidcCallbackURI, oauthOidcCallback(config_obj, provider))
 
-	installLogoff(config_obj, mux)
-	return nil
+	return installLogoff(config_obj, mux)
 }
 
 func (*OidcAuthenticator) AuthenticateUserHandler(

--- a/api/authenticators/saml.go
+++ b/api/authenticators/saml.go
@@ -74,7 +74,7 @@ func (self *SamlAuthenticator) AddHandlers(config_obj *config_proto.Config, mux 
 
 func (self *SamlAuthenticator) AuthenticateUserHandler(
 	config_obj *config_proto.Config,
-	parent http.Handler) http.Handler {
+	parent http.Handler) (http.Handler, error) {
 
 	reject_handler := samlMiddleware.RequireAccount(parent)
 
@@ -130,7 +130,7 @@ Contact your system administrator to get an account, then try again.
 		GetLoggingHandler(config_obj)(parent).ServeHTTP(
 			w, r.WithContext(ctx))
 		return
-	})
+	}), nil
 }
 
 func userAttr(config_obj *config_proto.Config) string {

--- a/gui/velociraptor/b0x.yaml
+++ b/gui/velociraptor/b0x.yaml
@@ -15,6 +15,9 @@ custom:
   - files:
       - "gui/velociraptor/build/static/**"
       - "gui/velociraptor/build/index.html"
+      - "gui/velociraptor/build/unauthenticated.html.tmpl"
+      - "gui/velociraptor/build/unauthorized.html.tmpl"
+      - "gui/velociraptor/build/logoff.html.tmpl"
       - "gui/velociraptor/build/favicon.ico"
     base: "gui/velociraptor/build/"
     exclude:

--- a/gui/velociraptor/public/logoff.html.tmpl
+++ b/gui/velociraptor/public/logoff.html.tmpl
@@ -1,0 +1,3 @@
+<html><body>
+You have successfully logged off!
+</body></html>

--- a/gui/velociraptor/public/unauthenticated.html.tmpl
+++ b/gui/velociraptor/public/unauthenticated.html.tmpl
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <link rel="shortcut icon" href="{{.BasePath}}/app/favicon.ico" />
+    <title>Velociraptor Response and Monitoring: Authentication Required</title>
+  </head>
+  <body id="body" class="{{.UserTheme}}">
+    <div id="root">
+     <h1>Authentication Required</h1>
+     <p>You must be successfully authenticated with a valid account to access this system.</p>
+     <p><a href="{{.LoginUrl}}" style="text-transform:none">Login with {{.Provider}}</a></p>
+    </div>
+  </body>
+</html>

--- a/gui/velociraptor/public/unauthorized.html.tmpl
+++ b/gui/velociraptor/public/unauthorized.html.tmpl
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <link rel="shortcut icon" href="{{.BasePath}}/app/favicon.ico" />
+    <title>Velociraptor Response and Monitoring: Authorization Required</title>
+  </head>
+  <body id="body" class="{{.UserTheme}}">
+    <div id="root">
+     <h1>Authorization Required</h1>
+     <p>You must be successfully authenticated with a valid account to access this system.</p>
+     <p>The account {{.Username}} is not registered on this system or does not have sufficient permissions.</p>
+     <p><a href="{{.LoginUrl}}" style="text-transform:none">Login with {{.Provider}}</a></p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR allows the builder to create their own template pages for unauthenticated users, unauthorized users, and logoff rather than relying on the default simple html messages. This works only for OAUTH2 for now.