### PR TITLE
UI Improvements

### DIFF
--- a/api/proto/api.pb.gw.go
+++ b/api/proto/api.pb.gw.go
@@ -22,8 +22,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
-	proto_2 "www.velocidex.com/golang/velociraptor/artifacts/proto"
-	proto_3 "www.velocidex.com/golang/velociraptor/flows/proto"
+	proto_5 "www.velocidex.com/golang/velociraptor/artifacts/proto"
+	proto_1 "www.velocidex.com/golang/velociraptor/flows/proto"
 )
 
 // Suppress "imported and not used" errors
@@ -1017,7 +1017,7 @@ func local_request_API_GetTable_0(ctx context.Context, marshaler runtime.Marshal
 }
 
 func request_API_CollectArtifact_0(ctx context.Context, marshaler runtime.Marshaler, client APIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_3.ArtifactCollectorArgs
+	var protoReq proto_1.ArtifactCollectorArgs
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -1034,7 +1034,7 @@ func request_API_CollectArtifact_0(ctx context.Context, marshaler runtime.Marsha
 }
 
 func local_request_API_CollectArtifact_0(ctx context.Context, marshaler runtime.Marshaler, server APIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_3.ArtifactCollectorArgs
+	var protoReq proto_1.ArtifactCollectorArgs
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -1351,7 +1351,7 @@ var (
 )
 
 func request_API_GetToolInfo_0(ctx context.Context, marshaler runtime.Marshaler, client APIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_2.Tool
+	var protoReq proto_5.Tool
 	var metadata runtime.ServerMetadata
 
 	if err := req.ParseForm(); err != nil {
@@ -1367,7 +1367,7 @@ func request_API_GetToolInfo_0(ctx context.Context, marshaler runtime.Marshaler,
 }
 
 func local_request_API_GetToolInfo_0(ctx context.Context, marshaler runtime.Marshaler, server APIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_2.Tool
+	var protoReq proto_5.Tool
 	var metadata runtime.ServerMetadata
 
 	if err := req.ParseForm(); err != nil {
@@ -1383,7 +1383,7 @@ func local_request_API_GetToolInfo_0(ctx context.Context, marshaler runtime.Mars
 }
 
 func request_API_SetToolInfo_0(ctx context.Context, marshaler runtime.Marshaler, client APIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_2.Tool
+	var protoReq proto_5.Tool
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -1400,7 +1400,7 @@ func request_API_SetToolInfo_0(ctx context.Context, marshaler runtime.Marshaler,
 }
 
 func local_request_API_SetToolInfo_0(ctx context.Context, marshaler runtime.Marshaler, server APIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_2.Tool
+	var protoReq proto_5.Tool
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -1469,7 +1469,7 @@ func local_request_API_GetServerMonitoringState_0(ctx context.Context, marshaler
 }
 
 func request_API_SetServerMonitoringState_0(ctx context.Context, marshaler runtime.Marshaler, client APIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_3.ArtifactCollectorArgs
+	var protoReq proto_1.ArtifactCollectorArgs
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -1486,7 +1486,7 @@ func request_API_SetServerMonitoringState_0(ctx context.Context, marshaler runti
 }
 
 func local_request_API_SetServerMonitoringState_0(ctx context.Context, marshaler runtime.Marshaler, server APIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_3.ArtifactCollectorArgs
+	var protoReq proto_1.ArtifactCollectorArgs
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -1507,7 +1507,7 @@ var (
 )
 
 func request_API_GetClientMonitoringState_0(ctx context.Context, marshaler runtime.Marshaler, client APIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_3.GetClientMonitoringStateRequest
+	var protoReq proto_1.GetClientMonitoringStateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := req.ParseForm(); err != nil {
@@ -1523,7 +1523,7 @@ func request_API_GetClientMonitoringState_0(ctx context.Context, marshaler runti
 }
 
 func local_request_API_GetClientMonitoringState_0(ctx context.Context, marshaler runtime.Marshaler, server APIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_3.GetClientMonitoringStateRequest
+	var protoReq proto_1.GetClientMonitoringStateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := req.ParseForm(); err != nil {
@@ -1539,7 +1539,7 @@ func local_request_API_GetClientMonitoringState_0(ctx context.Context, marshaler
 }
 
 func request_API_SetClientMonitoringState_0(ctx context.Context, marshaler runtime.Marshaler, client APIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_3.ClientEventTable
+	var protoReq proto_1.ClientEventTable
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -1556,7 +1556,7 @@ func request_API_SetClientMonitoringState_0(ctx context.Context, marshaler runti
 }
 
 func local_request_API_SetClientMonitoringState_0(ctx context.Context, marshaler runtime.Marshaler, server APIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq proto_3.ClientEventTable
+	var protoReq proto_1.ClientEventTable
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)

--- a/artifacts/definitions/Demo/Plugins/GUI.yaml
+++ b/artifacts/definitions/Demo/Plugins/GUI.yaml
@@ -82,6 +82,16 @@ parameters:
     type: upload
     description: FileUpload1 can receive a file upload. The upload content will be available in this variable when executing on the client.
 
+  - name: ArtifactSelections
+    type: artifactset
+    description: A selection of artifact
+    artifact_type: CLIENT_EVENT
+    default: |
+      Artifact
+      Windows.Detection.PsexecService
+      Windows.Events.ProcessCreation
+      Windows.Events.ServiceCreation
+
 column_types:
   - name: Hex
     type: base64hex

--- a/gui/velociraptor/src/components/clients/host-info.js
+++ b/gui/velociraptor/src/components/clients/host-info.js
@@ -19,6 +19,7 @@ import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import Spinner from '../utils/spinner.js';
 import Form from 'react-bootstrap/Form';
+import Alert from 'react-bootstrap/Alert';
 
 import { Link } from  "react-router-dom";
 import api from '../core/api-service.js';
@@ -30,23 +31,58 @@ import { runArtifact } from "../flows/utils.js";
 const POLL_TIME = 5000;
 const INTERROGATE_POLL_TIME = 2000;
 
+var quarantine_artifacts = {
+    "windows": "Windows.Remediation.Quarantine",
+    "linux": "Linux.Remediation.Quarantine",
+    "macos": "MacOS.Remediation.Quarantine",
+};
+
 class QuarantineDialog extends Component {
     static propTypes = {
         client: PropTypes.object,
         onClose: PropTypes.func.isRequired,
     }
 
-    state = {
-        loading: false,
-        message: "",
+    constructor(props) {
+        super(props);
+        this.state = {
+            loading: false,
+            message: "",
+            quarantine_available: false,
+            quarantine_artifact: quarantine_artifacts[props.client.os_info.system],
+        }
     }
 
     componentDidMount = () => {
         this.source = axios.CancelToken.source();
+        this.checkQuarantineAvailability();
     }
 
     componentWillUnmount() {
         this.source.cancel();
+    }
+
+    checkQuarantineAvailability() {
+        // If the client is running on an OS other than Windows, Linux, or MacOS,
+        // they'll need to define an artifact name to use for it
+        if (this.state.quarantine_artifact === undefined) {
+            this.setState({'quarantine_available' : false});
+            return;
+        }
+
+        api.post("v1/GetArtifacts",
+                 {
+                     names: [this.state.quarantine_artifact],
+                     number_of_results: 1,
+                 },
+
+                 this.source.token).then((response) => {
+                    if (response.cancel) return;
+
+                    let items = response.data.items || [];
+
+                    this.setState({'quarantine_available' : items.length !== 0});
+                 });
     }
 
     startQuarantine = () => {
@@ -75,7 +111,7 @@ class QuarantineDialog extends Component {
         }
     }
 
-    render() {
+    renderAvailable() {
         return (
             <Modal show={true} onHide={this.props.onClose}>
               <Modal.Header closeButton>
@@ -110,6 +146,39 @@ class QuarantineDialog extends Component {
               </Modal.Footer>
             </Modal>
         );
+    }
+
+    renderUnavailable() {
+        let os_name = this.props.client.os_info.system || "an unknown operating system";
+
+        return (
+            <Modal show={true} onHide={this.props.onClose}>
+              <Modal.Header closeButton>
+                <Modal.Title>Cannot Quarantine host</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                <Alert variant="warning">
+                { this.state.quarantine_artifact ?
+                    <p>This Velociraptor instance does not have the <b>{this.state.quarantine_artifact}</b> artifact required to quarantine hosts running {os_name}.</p> :
+                    <p>This Velociraptor instance does not have an artifact name defined to quarantine hosts running {os_name}.</p>
+                }
+                </Alert>
+              </Modal.Body>
+              <Modal.Footer>
+                <Button variant="primary" onClick={this.props.onClose}>
+                  Close
+                </Button>
+              </Modal.Footer>
+            </Modal>
+        )
+    }
+
+    render() {
+        if (this.state.quarantine_available) {
+            return this.renderAvailable();
+        } else {
+            return this.renderUnavailable();
+        }
     }
 }
 

--- a/gui/velociraptor/src/components/clients/shell-viewer.js
+++ b/gui/velociraptor/src/components/clients/shell-viewer.js
@@ -460,6 +460,13 @@ class ShellViewer extends Component {
             shell_type: props.default_shell || 'Powershell',
             command: "",
         };
+
+        this.state.client_os = props.client.os_info.system;
+
+        // Powershell can exist on Linux/MacOS but Bash is a more reasonable default
+        if (this.state.client_os && this.state.client_os !== "windows") {
+            this.state.shell_type = 'Bash';
+        }
     }
 
     componentDidMount() {
@@ -618,8 +625,10 @@ class ShellViewer extends Component {
                                     onSelect={(e) => this.setType(e)}
                                     id="bg-nested-dropdown">
                       <Dropdown.Item eventKey="Powershell">Powershell</Dropdown.Item>
-                      <Dropdown.Item eventKey="Cmd">Cmd</Dropdown.Item>
-                      <Dropdown.Item eventKey="Bash">Bash</Dropdown.Item>
+                      { (!this.state.client_os || this.state.client_os === "windows") &&
+                           <Dropdown.Item eventKey="Cmd">Cmd</Dropdown.Item> }
+                      { (!this.state.client_os || this.state.client_os !== "windows") &&
+                           <Dropdown.Item eventKey="Bash">Bash</Dropdown.Item> }
                       <Dropdown.Item eventKey="VQL">VQL</Dropdown.Item>
                     </DropdownButton>
                   </InputGroup.Prepend>

--- a/gui/velociraptor/src/components/forms/form.js
+++ b/gui/velociraptor/src/components/forms/form.js
@@ -112,14 +112,12 @@ export default class VeloForm extends React.Component {
         api.post("v1/GetArtifacts",
                 {
                     search_term: "...",
+                    type: artifact_type,
+
+                    // No field type: We want the list of sources too
+
                     // This might be too many to fetch at once but we
                     // are still fast enough for now.
-                    fields: {
-                        name: true,
-                        type: true,
-                        description: true,
-                    },
-                    type: artifact_type,
                     number_of_results: 1000,
                 },
 
@@ -134,13 +132,46 @@ export default class VeloForm extends React.Component {
                     });
 
                     for (let i=0; i < items.length; i++) {
-                        var desc = items[i];
-                        artifacts[desc.name] = {
-                            'description' : desc.description,
-                            'enabled' : false,
-                        };
-                        if (checkedArtifacts.indexOf(desc.name) !== -1) {
-                            artifacts[desc.name].enabled = true;
+                        let desc = items[i];
+
+                        let sources = desc.sources || [];
+                        let selectable_names = [];
+                        let descriptions = {};
+                        let unnamed_source = false;
+
+                        // Gather the list of possible sources so the user
+                        // can select them individually.  If there is only
+                        // one source, it may not be named or have a separate
+                        // description.
+                        for (let j=0; j < sources.length; j++) {
+                            if (sources[j].name) {
+                                let name = desc.name + "/" + sources[j].name;
+
+                                selectable_names.push(name);
+                                if (sources[j].description) {
+                                    descriptions[name] = sources[j].description;
+                                } else {
+                                    descriptions[name] = desc.description;
+                                }
+                            } else {
+                                unnamed_source = true;
+                            }
+                        }
+
+                        if (unnamed_source) {
+                            selectable_names.push(desc.name);
+                            descriptions[desc.name] = desc.description;
+                        }
+
+                        for (let j=0; j < selectable_names.length; j++) {
+                            let name = selectable_names[j];
+                            artifacts[name] = {
+                                'description' : descriptions[name],
+                                'enabled' : false,
+                            };
+                            if (checkedArtifacts.indexOf(name) !== -1) {
+                                artifacts[name].enabled = true;
+                            }
                         }
                     };
 

--- a/gui/velociraptor/src/components/forms/form.js
+++ b/gui/velociraptor/src/components/forms/form.js
@@ -76,18 +76,32 @@ export default class VeloForm extends React.Component {
         // A Date() object that is parsed from value in local time.
         timestamp: null,
         multichoices: undefined,
+        artifact_loading: false,
     }
 
     componentDidMount = () => {
         this.source = axios.CancelToken.source();
-        this.fetchArtifacts(this.props.param.artifact_type);
+        this.maybeFetchArtifacts(this.props.param.artifact_type);
+    }
+
+    componentDidUpdate = (prevProps, prevState, rootNode) => {
+        this.maybeFetchArtifacts(this.props.param.artifact_type);
     }
 
     componentWillUnmount() {
         this.source.cancel();
     }
 
-    fetchArtifacts(artifact_type) {
+    maybeFetchArtifacts(artifact_type) {
+        if (!artifact_type || !this.props.param ||
+            this.props.param.type !== "artifactset") {
+            return;
+        }
+
+        // Only fetch the list once.
+        if (this.state.multichoices !== undefined) {
+            return;
+        }
 
         // Cancel any in flight calls.
         this.source.cancel();
@@ -105,16 +119,14 @@ export default class VeloForm extends React.Component {
                         type: true,
                         description: true,
                     },
-
                     type: artifact_type,
-
                     number_of_results: 1000,
                 },
 
                 this.source.token).then((response) => {
                     if (response.cancel) return;
 
-                    let artifacts = {}
+                    let artifacts = {};
                     let items = response.data.items || [];
                     let data = parseCSV(this.props.value);
                     let checkedArtifacts = _.map(data.data, function(item, idx) {
@@ -137,6 +149,7 @@ export default class VeloForm extends React.Component {
 
                     this.setState({
                         multichoices: artifacts,
+                        artifact_loading: false,
                         unavailableArtifacts: unavailableArtifacts,
                     });
                 });
@@ -427,15 +440,20 @@ export default class VeloForm extends React.Component {
             );
         case "artifactset":
             // No artifacts means we haven't loaded yet.  If there are truly no artifacts, we've got bigger problems.
-            if (this.state.multichoices === undefined) {
+            if (this.state.multichoices === undefined ||
+                this.state.artifact_loading) {
               return <></>;
             }
             if (Object.keys(this.state.multichoices).length === 0) {
                 return (
                   <Form.Group as={Row}>
-                    <Alert variant="danger">Warning: No artifacts found for type {this.props.param.artifact_type}.</Alert>
+                    <Alert variant="danger">
+                      Warning: No artifacts found for type {
+                          this.props.param.artifact_type
+                      }.
+                    </Alert>
                   </Form.Group>
-                )
+                );
             }
             return (
                 <Form.Group as={Row}>
@@ -452,6 +470,7 @@ export default class VeloForm extends React.Component {
                       { _.map(Object.keys(this.state.multichoices), (key, idx) => {
                         return (
                             <OverlayTrigger
+                              key={key}
                               delay={{show: 250, hide: 400}}
                               overlay={(props)=>renderToolTip(props, this.state.multichoices[key])}>
                               <div>

--- a/vql/tools/fixtures/TestSimpleCollection.golden
+++ b/vql/tools/fixtures/TestSimpleCollection.golden
@@ -112,6 +112,10 @@
     },
     {
      "key": "FileUpload1"
+    },
+    {
+     "key": "ArtifactSelections",
+     "value": "Artifact\nWindows.Detection.PsexecService\nWindows.Events.ProcessCreation\nWindows.Events.ServiceCreation\n"
     }
    ],
    "Query": [
@@ -153,6 +157,9 @@
     },
     {
      "VQL": "LET FileUpload1 \u003c= FileUpload1_.Content[0]"
+    },
+    {
+     "VQL": "\nLET ArtifactSelections \u003c= SELECT * FROM if(\n    condition=format(format=\"%T\", args=ArtifactSelections) =~ \"string\",\n    then={SELECT * FROM parse_csv(filename=ArtifactSelections, accessor='data')},\n    else=ArtifactSelections)\n"
     },
     {
      "VQL": "LET Demo_Plugins_GUI_0_0 = SELECT base64encode(string=\"This should popup in a hex editor\") AS Hex, ChoiceSelector, Flag, Flag2, Flag3, OffFlag, StartDate, StartDate2, StartDate3, CSVData, CSVData2, JSONData, JSONData2, len(list=FileUpload1) AS FileUpload1Length FROM scope()"


### PR DESCRIPTION
This PR contains a few UI improvements:

- In the Shell interface, we don't need to present shell options on operating systems that will not support them. Powershell is now open source and _could_ be on Linux and MacOS even if it's unlikely. Windows CMD will only be on Windows and Bash will not be installed, if it's installed at all, at a UNIX path on Windows. Instead, hide CMD on non-Windows and hide Bash on Windows. Additionally, on non-Windows clients, Bash is the default shell.
- The quarantine functionality is Windows-only ATM due to the artifact used being called `Windows.Remediation.Quarantine`. There's a precondition that ensures it doesn't run on !Windows, but the UI expects the query to run to completion just the same.  Instead, choose an appropriate artifact name based on the client OS and check that it exists. If it does not exist, pop a warning instead of attempting to do it anyway. This also means that adding quarantine support for Linux and MacOS is as simple as adding the appropriate artifact.