### PR TITLE
Sensor 0.6.4/gui fixes

### DIFF
--- a/gui/velociraptor/src/components/clients/host-info.js
+++ b/gui/velociraptor/src/components/clients/host-info.js
@@ -252,6 +252,8 @@ class VeloHostInfo extends Component {
                 loading: true,
             });
 
+	    let quarantine_artifact = quarantine_artifacts[this.props.client.os_info.system];
+
             // Add the quarantine label to this host.
             api.post("v1/LabelClients", {
                 client_ids: [client_id],
@@ -259,7 +261,7 @@ class VeloHostInfo extends Component {
                 labels: ["Quarantine"],
             }, this.source.token).then((response) => {runArtifact(
                 client_id,
-                this.state.quarantine_artifact,
+                quarantine_artifact,
                 {RemovePolicy: "Y"},
                 ()=>{
                     this.updateClientInfo();

--- a/gui/velociraptor/src/components/clients/host-info.js
+++ b/gui/velociraptor/src/components/clients/host-info.js
@@ -65,7 +65,7 @@ class QuarantineDialog extends Component {
             }, this.source.token).then((response) => {
                 runArtifact(
                     client_id,
-                    "Windows.Remediation.Quarantine",
+                    this.state.quarantine_artifact,
                     {MessageBox: this.state.message},
                     ()=>{
                         this.props.onClose();
@@ -259,7 +259,7 @@ class VeloHostInfo extends Component {
                 labels: ["Quarantine"],
             }, this.source.token).then((response) => {runArtifact(
                 client_id,
-                "Windows.Remediation.Quarantine",
+                this.state.quarantine_artifact,
                 {RemovePolicy: "Y"},
                 ()=>{
                     this.updateClientInfo();


### PR DESCRIPTION
Commit  5231b0f9b699f (host-info: make quarantine UI more robust with non-Windows client hosts) was incomplete and would only check to see if the platform-specific quarantine artifact existed.  It would still attempt to invoke the Windows quarantine artifact. This PR fixes it.