### PR TITLE
third_party/go-libaudit: don't directly use unix.*

### DIFF
--- a/third_party/go-libaudit/auparse/auparse.go
+++ b/third_party/go-libaudit/auparse/auparse.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 //go:generate sh -c "go run mk_audit_msg_types.go && gofmt -s -w zaudit_msg_types.go"
@@ -449,7 +447,7 @@ func setSignalName(data map[string]*field) error {
 		return fmt.Errorf("failed to parse sig: %w", err)
 	}
 
-	if signalName := unix.SignalName(syscall.Signal(signalNum)); signalName != "" {
+	if signalName := getSignalName(syscall.Signal(signalNum)); signalName != "" {
 		field.Set(signalName)
 	}
 	return nil

--- a/third_party/go-libaudit/auparse/signal_linux.go
+++ b/third_party/go-libaudit/auparse/signal_linux.go
@@ -1,0 +1,11 @@
+package auparse
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func getSignalName(signalNum syscall.Signal) string {
+        return unix.SignalName(syscall.Signal(signalNum))
+}

--- a/third_party/go-libaudit/auparse/signal_wrapper.go
+++ b/third_party/go-libaudit/auparse/signal_wrapper.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package auparse
+
+import (
+	"syscall"
+)
+
+func getSignalName(signalNum syscall.Signal) string {
+        return syscall.Signal(signalNum).String()
+}


### PR DESCRIPTION
unix.SignalName doesn't exist on Windows and causes build failures.