### PR TITLE
api/authenticators: fix handling of missing oauthstate cookie for OAUTH2

### DIFF
--- a/api/authenticators/azure.go
+++ b/api/authenticators/azure.go
@@ -107,7 +107,7 @@ func (self *AzureAuthenticator) oauthAzureCallback() http.Handler {
 		// Read oauthState from Cookie
 		oauthState, _ := r.Cookie("oauthstate")
 
-		if r.FormValue("state") != oauthState.Value {
+		if oauthState == nil || r.FormValue("state") != oauthState.Value {
 			logging.GetLogger(self.config_obj, &logging.GUIComponent).
 				Error("invalid oauth azure state")
 			http.Redirect(w, r, "/", http.StatusTemporaryRedirect)

--- a/api/authenticators/github.go
+++ b/api/authenticators/github.go
@@ -105,7 +105,7 @@ func (self *GitHubAuthenticator) oauthGithubCallback() http.Handler {
 		// Read oauthState from Cookie
 		oauthState, _ := r.Cookie("oauthstate")
 
-		if r.FormValue("state") != oauthState.Value {
+		if oauthState == nil || r.FormValue("state") != oauthState.Value {
 			logging.GetLogger(self.config_obj, &logging.GUIComponent).
 				Error("invalid oauth github state")
 			http.Redirect(w, r, "/", http.StatusTemporaryRedirect)

--- a/api/authenticators/google.go
+++ b/api/authenticators/google.go
@@ -145,7 +145,7 @@ func (self *GoogleAuthenticator) oauthGoogleCallback() http.Handler {
 		// Read oauthState from Cookie
 		oauthState, _ := r.Cookie("oauthstate")
 
-		if r.FormValue("state") != oauthState.Value {
+		if oauthState == nil || r.FormValue("state") != oauthState.Value {
 			logging.GetLogger(self.config_obj, &logging.GUIComponent).
 				Error("invalid oauth google state")
 			http.Redirect(w, r, "/", http.StatusTemporaryRedirect)


### PR DESCRIPTION
I was able to crash Velociraptor by requesting the github authenticator
callback URL directly with e.g. curl https://vrrserver/auth/github/callback

It turns out that there was no error handling if there is no 'oauthstate'
cookie provided as part of the request and we hit a nil pointer
dereference panic.  The Google and Azure authenticators had the same
issue.

This commit fixes all three and resolves #1999.