### PR TITLE
file_store: handle watching artifacts with named sources

### DIFF
--- a/file_store/directory/listener.go
+++ b/file_store/directory/listener.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -239,6 +240,7 @@ func NewListener(
 		}
 
 		base_name := fmt.Sprintf("journal_%s_%s_", name, node_name)
+		base_name = strings.Replace(base_name, "/", "...", -1)
 		tmpfile, err := ioutil.TempFile("", base_name)
 		if err != nil {
 			return nil, err

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -34,6 +34,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/result_sets"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
@@ -71,6 +72,9 @@ func (self *QueuePool) Register(
 	subctx, cancel := context.WithCancel(ctx)
 	new_registration, err := NewListener(self.config_obj, subctx, vfs_path, options)
 	if err != nil {
+		logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
+		logger.Warn("Failed to register QueuePool for %s: %v", vfs_path, err)
+
 		cancel()
 		output_chan := make(chan *ordereddict.Dict)
 		close(output_chan)


### PR DESCRIPTION
When watch_monitoring() is called to monitor an artifact with a named source, it returns immediately with zero results and nothing in the log.

It turns out that file_store/directory/queue QueuePool.NewListener was failing silently due to the path containing a slash in it.  This commit replaces the slash with three dots and reports an error when it happens in NewListener.