### PR TITLE
Build fixes for non-AMD64 architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CLANG ?= clang
 LLVM_STRIP ?= llvm-strip
 CFLAGS := -g -O2 -Wall
-ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
+ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/s390x/s390/')
 EXTRA_TAGS =
 
 GOOS := $(shell go env | grep GOOS|sed -e 's/^.*=//'|tr -d '"')

--- a/magefile.go
+++ b/magefile.go
@@ -230,11 +230,18 @@ func Release() error {
 	return Windows()
 }
 
-func Linux() error {
+func LinuxAmd64() error {
 	return Builder{
 		extra_tags: " release yara ",
 		goos:       "linux",
 		arch:       "amd64"}.Run()
+}
+
+func Linux() error {
+	return Builder{
+		extra_tags: " release yara ",
+		goos:       "linux",
+		arch:       runtime.GOARCH}.Run()
 }
 
 func LinuxMusl() error {
@@ -248,11 +255,18 @@ func LinuxMusl() error {
 }
 
 // A Linux binary without the GUI
-func LinuxBare() error {
+func LinuxBareAmd64() error {
 	return Builder{
 		extra_tags: " release yara disable_gui ",
 		goos:       "linux",
 		arch:       "amd64"}.Run()
+}
+
+func LinuxBare() error {
+	return Builder{
+		extra_tags: " release yara disable_gui ",
+		goos:       "linux",
+		arch:       runtime.GOARCH}.Run()
 }
 
 func Freebsd() error {


### PR DESCRIPTION
Velociraptor has been building fine on OBS but it's limited to x86_64 and i586 (and we don't care about  i586). This PR includes fixes for building Velociraptor on non-x86_64 and syncs the libbpfgo submodule to include changes pushed upstream for building on non-x86_64.

The only code change is the handling of the `MAP_32BIT` flag for `mmap()` in libbpfgo which nothing should be using anyway.