### PR TITLE
Sensor base 0.6.7

### DIFF
--- a/vql/parsers/sdjournal/scanner_linux.go
+++ b/vql/parsers/sdjournal/scanner_linux.go
@@ -79,6 +79,12 @@ func prepareJournalEntry(entry *sdjournal.JournalEntry) *ordereddict.Dict {
 		d.Set(name, value)
 	}
 
+	// https://github.com/systemd/systemd/issues/1347
+	_, ok := entry.Fields["_SYSTEMD_UNIT"]
+	if !ok {
+		d.Set("_SYSTEMD_UNIT", "")
+	}
+
 	d.Set("REALTIME_TIMESTAMP", entry.RealtimeTimestamp)
 	d.Set("MONOTONIC_TIMESTAMP", entry.MonotonicTimestamp)
 


### PR DESCRIPTION
sdjournal: work around missing _SYSTEMD_UNIT fields
    
There is a longstanding issue in systemd where it attempts to figure out
who sent a message just after it received it.  By the time it does, the
process may have exited and it's unable to identify it.
    
For Velociraptor, this can result in errors like the following:
  [ERROR] 2023-01-12T10:22:30+01:00 Symbol _SYSTEMD_UNIT not found.
    
Systemd bug reference: https://github.com/systemd/systemd/issues/1347
