### PR TITLE
Sensor 0.6.7/fix ringbuffer tempfile directory

### DIFF
--- a/http_comms/ring_buffer.go
+++ b/http_comms/ring_buffer.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 
@@ -386,7 +386,7 @@ func NewFileBasedRingBuffer(
 	// (`C:\Program Files\Velociraptor\Tools`) so symlink attacks are
 	// mitigated but in case Velociraptor is misconfigured we are
 	// extra careful.
-	fd, err := ioutil.TempFile(".", "")
+	fd, err := os.CreateTemp(filepath.Dir(filename), "")
 	if err != nil {
 		return nil, err
 	}

--- a/vql/linux/cronsnoop/plugin.go
+++ b/vql/linux/cronsnoop/plugin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/logging"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
@@ -48,6 +49,14 @@ func (self CronsnoopPlugin) Call(
 			return
 		}
 
+		config_obj, ok := vql_subsystem.GetServerConfig(scope)
+		if !ok {
+			scope.Log("cronsnoop: Couldn't obtain server config")
+			return
+
+		}
+		logger := logging.GetLogger(config_obj, &logging.ClientComponent)
+
 		// Make the chan large enough so that cron snooper doesn't block, waiting
 		// for the channel too be consumed
 		eventChan := make(chan CronEvent, 1000)
@@ -58,6 +67,8 @@ func (self CronsnoopPlugin) Call(
 			scope.Log("cronsnoop: Error creating snooper instance", err)
 			return
 		}
+
+		snooper.SetLogger(logger)
 
 		defer snooper.Close()
 		err = snooper.WatchCrons()

--- a/vql/linux/cronsnoop/plugin.go
+++ b/vql/linux/cronsnoop/plugin.go
@@ -60,7 +60,11 @@ func (self CronsnoopPlugin) Call(
 		}
 
 		defer snooper.Close()
-		snooper.WatchCrons()
+		err = snooper.WatchCrons()
+		if err != nil {
+			scope.Log("cronsnoop: Error starting cron watchers: %v", err)
+			return
+		}
 
 		for {
 			select {

--- a/vql/linux/cronsnoop/plugin.go
+++ b/vql/linux/cronsnoop/plugin.go
@@ -55,7 +55,7 @@ func (self CronsnoopPlugin) Call(
 		defer close(eventChan)
 
 		if err != nil {
-			scope.Log("cronsnoop: Error creaing snooper instance", err)
+			scope.Log("cronsnoop: Error creating snooper instance", err)
 			return
 		}
 


### PR DESCRIPTION
Fixes an issue where the tempfile for the ring buffer is created in /, which could be read only and/or on a different file system than the target file path.