### PR TITLE
0.6.7-5 update

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
+        sudo apt-get update
         sudo apt-get install mingw-w64-x86-64-dev gcc-mingw-w64-x86-64 gcc-mingw-w64 libsystemd-dev clang-12 llvm libelf-dev git linux-tools-common make
 
     - name: Use Node.js v16

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
+        sudo apt-get update
         sudo apt-get install libsystemd-dev clang-12 llvm libelf-dev git linux-tools-common make
 
     - name: Build GUI-less binary

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "third_party/libbpfgo"]
 	path = third_party/libbpfgo
 	url = https://github.com/jeffmahoney/libbpfgo
+	branch = velociraptor-branch

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LIBBPF_DIR := $(LIBBPFGO_DIR)/libbpf
 LIBBPF_OUTPUT := $(LIBBPFGO_DIR)/output
 LIBBPF_LIB := $(LIBBPF_OUTPUT)/libbpf.a
 GIT := git
-EXTRA_TAGS += linuxbpf libbpfgo_full_static
+EXTRA_TAGS += linuxbpf libbpfgo_static
 else
 $(error Cannot build BPF objects without clang installed.  Install clang or build with BUILD_LIBBPFGO=0.)
 endif
@@ -77,7 +77,7 @@ $(LIBBPFGO_DIR): always-check
 	$(GIT) submodule update --init --recursive $@
 
 $(LIBBPF_LIB): $(LIBBPFGO_DIR)
-	make -C $(LIBBPFGO_DIR) libbpfgo-full-static
+	make -C $(LIBBPFGO_DIR) libbpfgo-static
 
 %.bpf.o: %.bpf.c $(LIBBPF_LIB)
 	$(CLANG) $(CFLAGS) -target bpf -D__TARGET_ARCH_$(ARCH)	      \

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	VERSION                    = "0.6.7-4"
+	VERSION                    = "0.6.7-5"
 	ENROLLMENT_WELL_KNOWN_FLOW = "E:Enrol"
 	MONITORING_WELL_KNOWN_FLOW = FLOW_PREFIX + "Monitoring"
 

--- a/paths/constants.go
+++ b/paths/constants.go
@@ -27,10 +27,10 @@ var (
 	NOTEBOOK_ROOT = path_specs.NewSafeDatastorePath("notebooks").
 			SetType(api.PATH_TYPE_DATASTORE_JSON)
 
-	DOWNLOADS_ROOT = path_specs.NewSafeFilestorePath("downloads").
+	DOWNLOADS_ROOT = path_specs.NewUnsafeFilestorePath("downloads").
 			SetType(api.PATH_TYPE_FILESTORE_DOWNLOAD_ZIP)
 
-	CLIENTS_ROOT = path_specs.NewSafeDatastorePath("clients").
+	CLIENTS_ROOT = path_specs.NewUnsafeDatastorePath("clients").
 			SetType(api.PATH_TYPE_DATASTORE_PROTO)
 
 	CONFIG_ROOT = path_specs.NewSafeDatastorePath("config").

--- a/services/indexing/simple.go
+++ b/services/indexing/simple.go
@@ -79,7 +79,7 @@ func (self *Indexer) CheckSimpleIndex(
 	for _, keyword := range keywords {
 		message := &emptypb.Empty{}
 		keyword = strings.ToLower(keyword)
-		subject := index_urn.AddChild(keyword, entity)
+		subject := index_urn.AddUnsafeChild(keyword, entity)
 		return db.GetSubject(config_obj, subject, message)
 	}
 	return errors.New("Client does not have label")

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -138,6 +138,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 )
 
@@ -537,6 +538,10 @@ func (self *Launcher) ScheduleArtifactCollectionFromCollectorArgs(
 	client_id := collector_request.ClientId
 	if client_id == "" {
 		return "", errors.New("Client id not provided.")
+	}
+
+	if !utils.ValidateClientId(client_id) {
+		return "", errors.New("Client id not valid.")
 	}
 
 	db, err := datastore.GetDB(config_obj)

--- a/utils/clientid.go
+++ b/utils/clientid.go
@@ -1,0 +1,12 @@
+package utils
+
+import "regexp"
+
+var (
+	// Client IDs always start with "C." or they can refer to the "server"
+	client_id_regex = regexp.MustCompile("^(C\\.[a-z0-9]+|server)")
+)
+
+func ValidateClientId(client_id string) bool {
+	return client_id_regex.MatchString(client_id)
+}

--- a/vql/filesystem/copy.go
+++ b/vql/filesystem/copy.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/acls"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -107,6 +108,14 @@ func (self *CopyFunction) Call(ctx context.Context,
 	if arg.Accessor != "data" {
 		scope.Log("copy: Copying file from %v into %v", arg.Filename,
 			arg.Destination)
+	}
+
+	// We are about to write on the filesystem - make sure the user
+	// has write access.
+	err = vql_subsystem.CheckAccess(scope, acls.FILESYSTEM_WRITE)
+	if err != nil {
+		scope.Log("copy: %s", err.Error())
+		return vfilter.Null{}
 	}
 
 	flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC

--- a/vql/server/compress.go
+++ b/vql/server/compress.go
@@ -42,7 +42,7 @@ func (self *Compress) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.FILESYSTEM_WRITE)
+	err := vql_subsystem.CheckAccess(scope, acls.FILESYSTEM_WRITE, acls.FILESYSTEM_READ)
 	if err != nil {
 		scope.Log("compress: %v", err)
 		return vfilter.Null{}


### PR DESCRIPTION
Update to upstream 0.6.7-5 which fixes two CVEs:
    - CVE-2023-0290: velociraptor: Directory Traversal In Client Id Parameter
    - CVE-2023-0242: velociraptor: Insufficient Permission Check In The VQL Copy() Function

Switch to using 'static' builds of libbpfgo instead of 'full-static' builds. This will use shared copies of libz and libelf.