### PR TITLE
cronsnoop: fix panic when crontab has empty line

### DIFF
--- a/vql/linux/cronsnoop/cron-lib.go
+++ b/vql/linux/cronsnoop/cron-lib.go
@@ -203,7 +203,7 @@ func special_cron_string(line_fields []string) bool {
 
 func should_skip_line(line_fields []string) bool {
 	// ignore comments and empty lines
-	if line_fields[0][0] == '#' || len(line_fields) == 0 {
+	if len(line_fields) == 0 || len(line_fields[0]) == 0 || line_fields[0][0] == '#' {
 		return true
 	}
 

--- a/vql/linux/cronsnoop/cron_test.go
+++ b/vql/linux/cronsnoop/cron_test.go
@@ -367,6 +367,13 @@ func TestMultiUserCommentIgnore(t *testing.T) {
 	assertMUserDoesntExist("user3", fName, s, t)
 }
 
+func TestShouldSkipLineEmptyLine(t *testing.T) {
+	fields := []string{""}
+	if !should_skip_line(fields) {
+		t.Fatal("Empty line should be skipped")
+	}
+}
+
 func TestMultiUserSpecialStringHandling(t *testing.T) {
 	tempdir := t.TempDir()
 


### PR DESCRIPTION
Blank lines are allowed in crontab files, but were failing with: panic: runtime error: index out of range [0] with length 0