### PR TITLE
sdjournal: Correctly seek to current tail

### DIFF
--- a/vql/parsers/sdjournal/watcher_linux.go
+++ b/vql/parsers/sdjournal/watcher_linux.go
@@ -112,6 +112,12 @@ func (self *JournalWatcherService) StartMonitoring() {
 		return
 	}
 
+	_, err = self.journal.Previous()
+	if err != nil {
+		scope.Log("Failed to set read pointer to previous journal entry: %v", err)
+		return
+	}
+
 	for {
 		status := self.journal.Wait(100 * time.Millisecond)
 


### PR DESCRIPTION
SeekTail() seeks to one position after the current tail. 
We need to call Previous() after SeekTail() to seek to the last journal entry.
Fixes a regression with systemd v254.

See https://github.com/systemd/systemd/pull/26577