### PR TITLE
sdjournal: Correctly seek to current tail (0.7.0)

### DIFF
--- a/vql/linux/sdjournal/watcher.go
+++ b/vql/linux/sdjournal/watcher.go
@@ -113,6 +113,12 @@ func (self *JournalWatcherService) StartMonitoring(journal *sdjournal.Journal) {
 		return
 	}
 
+	_, err = journal.Previous()
+	if err != nil {
+		scope.Log("Failed to set read pointer to previous journal entry: %v", err)
+		return
+	}
+
 	for {
 		status := journal.Wait(100 * time.Millisecond)
 


### PR DESCRIPTION
SeekTail() seeks to one position after the current tail. 
We need to call Previous() after SeekTail() to seek to the last journal entry.
Fixes a regression with systemd v254.

See https://github.com/systemd/systemd/pull/26577