### PR TITLE
Raise client connection log level to ERROR

### DIFF
--- a/http_comms/comms.go
+++ b/http_comms/comms.go
@@ -489,7 +489,7 @@ func (self *HTTPConnector) rekeyNextServer(ctx context.Context) error {
 	}
 
 	if err != nil {
-		self.logger.Info("While getting %v: %v", url, err)
+		self.logger.Error("While getting %v: %v", url, err)
 		if strings.Contains(err.Error(), "cannot validate certificate") {
 			self.logger.Info("If you intend to connect to a self signed " +
 				"VelociraptorServer, make sure Client.use_self_signed_ssl " +


### PR DESCRIPTION
Now messages about connection failures will be logged if the client is started without the verbose flag.