### PR TITLE
Add artifact to monitor ssh authorized_keys files

### DIFF
--- a/artifacts/definitions/Linux/Ssh/KnownHosts.yaml
+++ b/artifacts/definitions/Linux/Ssh/KnownHosts.yaml
@@ -26,7 +26,7 @@ sources:
           query={
             SELECT Uid, User, OSPath, Hostname, Type, PublicKey
             FROM split_records(
-               filenames=OSPath, regex=" ", record_regex="\n",
+               filenames=OSPath, regex=" ",
                columns=["Hostname", "Type", "PublicKey"])
             /* Ignore comment lines. */
             WHERE not Hostname =~ "^[^#]+#"

--- a/artifacts/definitions/Linux/Sys/Users.yaml
+++ b/artifacts/definitions/Linux/Sys/Users.yaml
@@ -11,5 +11,5 @@ sources:
       SELECT User, Description, Uid, Gid, Homedir, Shell
       FROM split_records(
             filenames=PasswordFile,
-            regex=":", record_regex="\n",
+            regex=":",
             columns=["User", "X", "Uid", "Gid", "Description", "Homedir", "Shell"])

--- a/artifacts/definitions/SUSE/Linux/Events/SshAuthorizedKeys.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/SshAuthorizedKeys.yaml
@@ -1,0 +1,24 @@
+name: SUSE.Linux.Events.SshAuthorizedKeys
+
+description: |
+  This monitoring artifact watches for changes to the .ssh/authorized_keys
+  in each user home directory.
+
+precondition: |
+  SELECT OS From info() where OS = 'linux'
+
+type: CLIENT_EVENT
+
+parameters:
+  - name: period
+    description: Seconds between checks
+    type: int
+    default: 600
+
+sources:
+  - query: |
+      SELECT Mtime AS Timestamp, User, Uid, OSPath AS Path, Diff AS Change, Key, Comment FROM diff(
+        query={ SELECT *, join(array=[User, Key]) AS _diffKey FROM Artifact.Linux.Ssh.AuthorizedKeys() },
+        key="_diffKey",
+        period=period)
+


### PR DESCRIPTION
This is a client event artifact that uses the diff() plugin to call Linux.Ssh.AuthorizedKeys at regular intervals and produce rows if there are any changes.