### PR TITLE
Add SUSE.Linux.Events.Timers artifact

### DIFF
--- a/artifacts/definitions/SUSE/Linux/Events/Timers.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/Timers.yaml
@@ -1,0 +1,30 @@
+name: SUSE.Linux.Events.Timers
+description: |
+   Print events when a systemd timer gets added/deleted/executed
+
+type: CLIENT_EVENT
+
+sources:
+  - name: TimerStateChange
+    precondition: SELECT OS From info() where OS = 'linux'
+    description: Collect event when a new timer is started or stopped
+    query: |
+      SELECT timestamp(string=REALTIME_TIMESTAMP) as Time,
+              JOB_TYPE AS Action,
+              UNIT As Timer
+        FROM watch_journal()
+        WHERE SYSLOG_IDENTIFIER = "systemd" AND CODE_FUNC = "job_emit_done_message" AND UNIT =~ ".*timer"
+
+  - name: TimerExecs
+    precondition: SELECT OS From info() where OS = 'linux'
+    description: Collect systemd timer executions from journal
+    query: |
+      LET timers = SELECT parse_json_array(data=Stdout) AS list
+        FROM execve(argv=['systemctl', 'list-timers', '--all', '-o', 'json', '--no-pager'])
+
+      LET timer_execs = SELECT *, {SELECT activates from timers.list} AS activates
+        FROM Artifact.SUSE.Linux.Events.Services()
+        WHERE format(format="%s%s" , args=[Service, ".service"]) in activates
+
+      SELECT Timestamp, PID, User, Process as Cmd, Description
+        FROM timer_execs


### PR DESCRIPTION
This artifact collects systemd timer executions.

I'm using `systemctl list-timers` with json output in order to get a list of services that are activated by timers, since we need to watch for the actual services in order to get information like Pid, Cmd and output (Line).
Let me know if there are any easier/better ways to do this.

There is one limitation: This doesn't appear to work for transient timers (e.g. running `systemd-run --on-active=30s somecommand`), but I couldn't find any way to make it work for these cases.