### PR TITLE
hash: fix nil pointer dereference panic

### DIFF
--- a/vql/functions/hash.go
+++ b/vql/functions/hash.go
@@ -299,6 +299,9 @@ func (self *HashFunction) Call(ctx context.Context,
 		if useCache {
 			if entry == nil {
 				entry, err = newHashResultCacheEntry(path)
+				if err != nil {
+					entry = nil
+				}
 			}
 
 			if entry != nil {


### PR DESCRIPTION
When newHashResultCacheEntry() failed the returned nil pointer was assigned to the entry interface. Later entry!=nil would evaluate to true and try to use it. Fix by setting entry to nil when newHashResultCacheEntry() fails.

Fixes https://github.com/SUSE/linux-security-sensor/issues/85