### PR TITLE
velociraptor: add dummy main function for mage

### DIFF
--- a/dummy-mage-vendoring.go
+++ b/dummy-mage-vendoring.go
@@ -1,0 +1,13 @@
+// +build useless
+
+// This will never be built but it will be evaluated by 'go mod vendor'
+// to ensure that all of mage is pulled in.
+
+package main
+
+import (
+	"github.com/magefile/mage"
+)
+
+func main() {
+}


### PR DESCRIPTION
Mage won't pull in the full dependencies without there being a real import.  This isn't used in the executable, since that's in bin/, but it will be used for 'go mod vendor'