### PR TITLE
vql/linux/audit: register PID when auditd is not running

### DIFF
--- a/vql/linux/audit/audit_client.go
+++ b/vql/linux/audit/audit_client.go
@@ -53,6 +53,13 @@ func (self *realCommandClient) GetStatus() (*libaudit.AuditStatus, error) {
 	return self.client.GetStatus()
 }
 
+func (self *realCommandClient) SetPID(wm libaudit.WaitMode) error {
+	if self.client == nil {
+		return clientNotOpenErr
+	}
+	return self.client.SetPID(wm)
+}
+
 func (self *realCommandClient) SetEnabled(enabled bool, wm libaudit.WaitMode) error {
 	if self.client == nil {
 		return clientNotOpenErr

--- a/vql/linux/audit/audit_service.go
+++ b/vql/linux/audit/audit_service.go
@@ -90,6 +90,7 @@ type commandClient interface {
 	DeleteRule(rule []byte) error
 	GetRules() ([][]byte, error)
 	GetStatus() (*libaudit.AuditStatus, error)
+	SetPID(wm libaudit.WaitMode) error
 	SetEnabled(enabled bool, wm libaudit.WaitMode) error
 	Close() error
 }
@@ -241,6 +242,16 @@ func (self *auditService) runService() error {
 			return fmt.Errorf("failed to enable audit subsystem: %w", err)
 		}
 		self.logger.Info("audit: enabled kernel audit subsystem")
+	}
+
+	if status.PID == 0 {
+		err = self.commandClient.SetPID(libaudit.WaitForReply)
+		if err != nil {
+			cancel()
+			self.commandClient.Close()
+			self.listener.Close()
+			return fmt.Errorf("failed to set audit PID: %w", err)
+		}
 	}
 
 	// Can only fail if self is nil


### PR DESCRIPTION
If the audit daemon PID is not set, register our own PID as audit daemon.

Fixes syslog getting flooded with audit events when auditd is not running.