### PR TITLE
Guard use of sysinfo() in Generic.Client.Info

### DIFF
--- a/artifacts/definitions/Generic/Client/Info.yaml
+++ b/artifacts/definitions/Generic/Client/Info.yaml
@@ -37,8 +37,7 @@ sources:
     description: Linux specific information about the host
     precondition: SELECT OS From info() where OS = 'linux'
     query: |
-      SELECT
-      sysinfo() AS `Computer Info`,
+      SELECT if(condition=version(function='sysinfo') != NULL, then=sysinfo()) AS `Computer Info`,
       { SELECT Name, HardwareAddrString AS MACAddress,
                Up, PointToPoint,
                AddrsString AS IPAddresses


### PR DESCRIPTION
The v0.6.7 client does not have the sysinfo() function, so interrogating them fails after the server is upgraded to v0.7.0+.

https://github.com/Velocidex/velociraptor/issues/3180