### PR TITLE
tcpsnoop: fix garbled results on s390

### DIFF
--- a/vql/linux/bpf/tcpsnoop/tcpsnoop.go
+++ b/vql/linux/bpf/tcpsnoop/tcpsnoop.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package bpf
@@ -76,7 +77,7 @@ func (self TcpsnoopPlugin) Call(
 			var event TcpsnoopEvent
 
 			// Parses raw event from the ebpf map
-			err := binary.Read(bytes.NewBuffer(data), binary.LittleEndian, &event)
+			err := binary.Read(bytes.NewBuffer(data), binary.NativeEndian, &event)
 
 			// Now we make into a more userfriendly struct for sending to VRR
 			event2 := Event{


### PR DESCRIPTION
s390 is big-endian, so decoding as little-endian was giving wrong results. Using native-endian works on both be and le machines.