### PR TITLE
Fix systemd Services artifact missing events

### DIFF
--- a/artifacts/definitions/SUSE/Linux/Events/Services.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/Services.yaml
@@ -23,26 +23,21 @@ sources:
                  FROM execve(argv=["systemctl", "show", name, "--value", "--property=ExecMainPID,ExecStart,Description,ActiveState"]) },
           column="parsed")
 
-       -- the audit plugin may return "unset" for the uid when the event ran as root
-      LET normalize(uid) = if(condition=uid="unset", then="0", else=uid)
-
-      LET userCache <= memoize(
-        query={ SELECT User, Uid FROM Artifact.Linux.Sys.Users() },
-        key='Uid',
-        period=3600)
-
       LET serviceStartEvents = SELECT
-        Timestamp,
-        Sequence,
-        str(str=Type) AS RecordType,
-        Data.unit AS Service,
-        { SELECT get(item=userCache, field=normalize(uid=Summary.Actor.Primary)).User FROM scope() } AS User,
-        { SELECT * FROM serviceDetails(name=Data.unit) } AS details
-      FROM audit()
-      WHERE RecordType = "SERVICE_START"
+        timestamp(epoch=REALTIME_TIMESTAMP) AS Timestamp,
+        UNIT AS Service,
+        _UID AS UID,
+        { SELECT * FROM serviceDetails(name=UNIT) } AS details
+      FROM watch_journal()
+      WHERE SYSLOG_IDENTIFIER = "systemd"
+        AND JOB_TYPE = "start"
+        AND JOB_RESULT = "done"
+        AND _PID = "1"
 
       SELECT
-        Timestamp, Sequence, Service, User,
+        Timestamp,
+        Service,
+        "root" AS User,
         details.pid AS PID,
         details.process AS Process,
         details.description AS Description,


### PR DESCRIPTION
For some reason the audit plugin does not see SERVICE_START events when velociraptor-client runs as a systemd service on SLES. The same works on Tumbleweed, and when run outside of systemd on SLES. Fix by using the watch_journal plugin instead.