### PR TITLE
Fix services artifact symbol pid not found error

### DIFF
--- a/artifacts/definitions/SUSE/Linux/Events/Services.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/Services.yaml
@@ -33,6 +33,7 @@ sources:
         AND JOB_TYPE = "start"
         AND JOB_RESULT = "done"
         AND _PID = "1"
+        AND UNIT =~ "service$"
 
       SELECT
         Timestamp,


### PR DESCRIPTION
These errors were happening when systemd session scope units started. Fix by filtering in .service units only.