### PR TITLE
Fix undefined binary.NativeEndian build errors

### DIFF
--- a/utils/endian.go
+++ b/utils/endian.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/binary"
 	"runtime"
 )
 
@@ -15,4 +16,11 @@ func init() {
 	default:
 		// nop
 	}
+}
+
+func NativeEndian() binary.ByteOrder {
+	if isBigEndian {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
 }

--- a/vql/linux/bpf/dnssnoop/ebpf.go
+++ b/vql/linux/bpf/dnssnoop/ebpf.go
@@ -11,6 +11,7 @@ import (
 	libbpf "github.com/aquasecurity/libbpfgo"
 	"golang.org/x/sys/unix"
 	"www.velocidex.com/golang/velociraptor/logging"
+	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql/linux/bpf"
 )
 
@@ -21,7 +22,7 @@ var bpfCode []byte
 func htons(i uint16) uint16 {
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, i)
-	return binary.NativeEndian.Uint16(b)
+	return utils.NativeEndian().Uint16(b)
 }
 
 func initSocket(bpfFd int) (int, error) {

--- a/vql/linux/bpf/tcpsnoop/tcpsnoop.go
+++ b/vql/linux/bpf/tcpsnoop/tcpsnoop.go
@@ -14,6 +14,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/logging"
+	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -82,12 +83,13 @@ func (self TcpsnoopPlugin) Call(
 		}
 
 		perfBuffer.Start()
+		nativeEndian := utils.NativeEndian()
 
 		for data := range eventsChan {
 			var event TcpsnoopEvent
 
 			// Parses raw event from the ebpf map
-			err := binary.Read(bytes.NewBuffer(data), binary.NativeEndian, &event)
+			err := binary.Read(bytes.NewBuffer(data), nativeEndian, &event)
 
 			// Now we make into a more userfriendly struct for sending to VRR
 			event2 := Event{


### PR DESCRIPTION
binary.NativeEndian is only available from go1.21 and some older distributions don't have it.