### PR TITLE
audit: fix auditBuf allocation and go vet warnings

### DIFF
--- a/artifacts/definitions/Linux/Events/ProcessExecutions.yaml
+++ b/artifacts/definitions/Linux/Events/ProcessExecutions.yaml
@@ -34,8 +34,6 @@ sources:
      // Enrich the original artifact with more data.
      SELECT Time, Pid, Ppid, UserId,
               { SELECT User from users WHERE Uid = UserId} AS User,
-              regex_replace(source=read_file(filename= "/proc/" + PPID + "/cmdline"),
-                            replace=" ", re="[\\0]") AS Parent,
               CmdLine,
               Exe, CWD,
               hashes.SHA1 AS SHA1,

--- a/utils/refcount.go
+++ b/utils/refcount.go
@@ -8,8 +8,8 @@ type Refcount struct {
 	count atomic.Int32
 }
 
-func NewRefcount() Refcount {
-	ref := Refcount{}
+func NewRefcount() *Refcount {
+	ref := &Refcount{}
 	ref.count.Store(1)
 
 	return ref
@@ -36,4 +36,8 @@ func (self *Refcount) Put() bool {
 		return true
 	}
 	return false
+}
+
+func (self *Refcount) Reset() {
+	self.count.Store(1)
 }

--- a/vql/linux/audit/audit_service.go
+++ b/vql/linux/audit/audit_service.go
@@ -121,7 +121,7 @@ type auditService struct {
 	unsubscribeChannel    chan *subscriber
 	shutdownChan          chan struct{}
 
-	rawBufPool sync.Pool
+	rawBufPool *sync.Pool
 
 	// Used only for stats reporting
 	totalMessagesReceivedCounter   AtomicCounter
@@ -137,7 +137,7 @@ type auditService struct {
 type auditBuf struct {
 	data     []byte
 	size     int
-	refcount utils.Refcount
+	refcount *utils.Refcount
 	pool     *sync.Pool
 }
 
@@ -160,16 +160,17 @@ func (self *auditBuf) Get() {
 func (self *auditBuf) Put() {
 	if self.refcount.Put() {
 		self.size = 0
+		self.refcount.Reset()
 		self.pool.Put(self)
 	}
 }
 
 func newAuditService(config_obj *config_proto.Config, logger *logging.LogContext, listener auditListener, client commandClient) *auditService {
 	bufSize := unix.NLMSG_HDRLEN + libaudit.AuditMessageMaxLength
-	rawBufPool := sync.Pool{}
+	rawBufPool := &sync.Pool{}
 
 	rawBufPool.New = func() any {
-		return newAuditBuf(bufSize, &rawBufPool)
+		return newAuditBuf(bufSize, rawBufPool)
 	}
 
 	return &auditService{
@@ -421,7 +422,7 @@ func (self *auditService) acceptEvents(ctx context.Context,
 		buf := self.rawBufPool.Get().(*auditBuf)
 		msgType, err := self.receiveMessageBuf(buf)
 		if err != nil {
-			self.rawBufPool.Put(buf)
+			buf.Put()
 			// Increased socket receive buffer
 			if errors.Is(err, errRetryNeeded) {
 				continue

--- a/vql/linux/audit/audit_service.go
+++ b/vql/linux/audit/audit_service.go
@@ -254,7 +254,7 @@ func (self *auditService) runService() error {
 
 	options := api.QueueOptions{
 		DisableFileBuffering: false,
-		FileBufferLeaseSize:  4096,
+		FileBufferLeaseSize:  64,
 		OwnerName:            "audit-plugin",
 	}
 


### PR DESCRIPTION
Profiling with pprof/allocs showed newAuditBuf() to be allocating more than expected. Also there are a copylock problems:

go vet vql/linux/audit/*go
	vql/linux/audit/audit_service.go:177:18:
	literal copies lock value from rawBufPool: sync.Pool contains sync.noCopy

go vet utils/refcount.go
	utils/refcount.go:15:9:
	return copies lock value: command-line-arguments.Refcount
	contains sync/atomic.Int32 contains sync/atomic.noCopy

After fixing the copylocks by using pointers, trying to reuse buffers from the pool would cause a panic because the refcount was zero. Fix by resetting the refcount when returning the buffer the pool.