### PR TITLE
Improve connection logging at boot time

### DIFF
--- a/http_comms/comms.go
+++ b/http_comms/comms.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -401,8 +402,8 @@ func (self *HTTPConnector) advanceToNextServer(ctx context.Context) {
 		wait := self.maxPoll + time.Duration(
 			GetRand()(int(self.maxPollDev)))*time.Second
 
-		self.logger.Info(
-			"Waiting for a reachable server: %v", wait)
+		fmt.Fprintf(os.Stderr,
+			"[INFO] Waiting for a reachable server: %v\n", wait)
 
 		// While we wait to reconnect we need to update the nanny or
 		// we get killed.
@@ -489,7 +490,7 @@ func (self *HTTPConnector) rekeyNextServer(ctx context.Context) error {
 	}
 
 	if err != nil {
-		self.logger.Error("While getting %v: %v", url, err)
+		fmt.Fprintf(os.Stderr, "[INFO] While getting %v: %v\n", url, err)
 		if strings.Contains(err.Error(), "cannot validate certificate") {
 			self.logger.Info("If you intend to connect to a self signed " +
 				"VelociraptorServer, make sure Client.use_self_signed_ssl " +
@@ -533,6 +534,7 @@ func (self *HTTPConnector) rekeyNextServer(ctx context.Context) error {
 
 	self.server_name = server_name
 	self.logger.Info("Received PEM for %v from %v", self.server_name, url)
+	fmt.Fprintf(os.Stderr, "[INFO] Connected to %v\n", url)
 
 	return nil
 }


### PR DESCRIPTION
End users need to know if the client service is working or not, and they do so by running `systemctl status velociraptor-client`. At boot time the client starts before the network and there is a "network is unreachable" message. We were logging this at ERROR level because INFO level messages won't show without --verbose, and that level is too verbose and spams the journal, see https://github.com/SUSE/linux-security-sensor/issues/65 . But end users only see error messages without any positive messages to say a connection was made, and they assume there is a problem. Fix this by writing failure/waiting/connected messages to stderr.