### PR TITLE
sdjournal: fix test build failure

### DIFF
--- a/vql/linux/sdjournal/watcher.go
+++ b/vql/linux/sdjournal/watcher.go
@@ -159,7 +159,7 @@ func (self *JournalWatcherService) monitorOnce(journal *sdjournal.Journal) (bool
 		entry, err := journal.GetEntry()
 		if err != nil {
 			logger := logging.GetLogger(self.config_obj, &logging.ClientComponent)
-			logger.Warning("Failed to read log entry: %v", err)
+			logger.Warn("Failed to read log entry: %v", err)
 			return true, err
 		}
 


### PR DESCRIPTION
$ go test www.velocidex.com/golang/velociraptor/vql/linux/sdjournal 
vql/linux/sdjournal/watcher.go:162:4: (*github.com/sirupsen/logrus.Logger).Warning
    call has possible Printf formatting directive %v
FAIL	www.velocidex.com/golang/velociraptor/vql/linux/sdjournal [build failed]