### PR TITLE
Fix shadowed variable in hash.go

### DIFF
--- a/vql/functions/hash.go
+++ b/vql/functions/hash.go
@@ -202,7 +202,8 @@ func (self *HashFunction) Call(ctx context.Context,
 	if useCache {
 		cache = GetHashResultCache(scope)
 
-		entry, isCached := cache.Get(path)
+		var isCached bool
+		entry, isCached = cache.Get(path)
 		if isCached {
 			isValid, _ := entry.Validate(path)
 			if isValid {


### PR DESCRIPTION
The entry variable is redeclared inside an if block and later sometimes set to nil within the block which has no effect on the entry variable in the outer block. Later in the outer block there is a comparison with nil which is always true. Fix by just assigning it in the inner block. Actually this makes no functional difference, but fixes a linter warning.