### PR TITLE
audit: fix watch rules in artifacts

### DIFF
--- a/artifacts/definitions/SUSE/Linux/Events/NewFilesNoOwner.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewFilesNoOwner.yaml
@@ -23,9 +23,19 @@ sources:
         sep="|"
       )
 
+      // function to make audit keys from paths e.g. /var/log/ -> vrr_var_log
+      LET path2key(path) = "vrr_" + regex_replace(source=strip(string=path, prefix="/", suffix="/"), replace="_", re="/")
+
+      // ["/home", "/var/log"] -> ["-w /home -p w -k vrr_home", "-w /var/log -p w -k vrr_var_log"]
       LET new_files_audit_rules = array(
-        a={ SELECT format(format='-w %s -p w -k vrr_unknown_uid_watch', args=_value)
+        a={ SELECT "-w " + _value + " -p w -k " + path2key(path=_value)
             FROM foreach(row=directories) }
+      )
+
+      // ["/home", "/var/log"] -> "^vrr_home$|^vrr_var_log$"
+      LET new_files_audit_keys_regex = join(
+        array=array(a={ SELECT "^" + path2key(path=_value) + "$"  FROM foreach(row=directories) }),
+        sep="|"
       )
 
       // cleans path with relpath - see https://pkg.go.dev/path/filepath#Rel
@@ -53,8 +63,8 @@ sources:
               Uid, set(item=known_uids, field=Uid, value=TRUE)
             FROM Artifact.Linux.Sys.Users()
           } AS _update_known_uids
-        FROM audit(rules="-w /etc/passwd -p w -k vrr_unknown_uids_etc_passwd")
-        WHERE "vrr_unknown_uids_etc_passwd" IN Tags
+        FROM audit(rules="-w /etc/passwd -p wa -k vrr_etc_passwd")
+        WHERE "vrr_etc_passwd" IN Tags
           AND Result = "success"
           AND Summary.action = "opened-file"
           AND log(message="/etc/passwd may have changed - reloading user uids", dedup=-1)
@@ -68,7 +78,7 @@ sources:
       // and adds a mapping to inode_to_path for each new file.
       LET new_file_events = SELECT _
         FROM audit(rules=new_files_audit_rules)
-        WHERE "vrr_unknown_uid_watch" IN Tags
+        WHERE any(items=Tags, regex=new_files_audit_keys_regex)
           AND Result = "success"
           AND Summary.action = "opened-file"
           AND Paths[-1].nametype = "CREATE"

--- a/artifacts/definitions/SUSE/Linux/Events/NewHiddenFile.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewHiddenFile.yaml
@@ -16,9 +16,17 @@ parameters:
 
 sources:
   - query: |
+      // function to make audit keys from paths e.g. /var/log/ -> vrr_var_log
+      LET path2key(path) = "vrr_" + regex_replace(source=strip(string=path, prefix="/", suffix="/"), replace="_", re="/")
+
       LET audit_rules = array(
-        a= { SELECT format(format='-w %s -p w -k vrr_hidden_files', args=_value)
-             FROM foreach(row=directories) })
+         a={ SELECT "-w " + _value + " -p w -k " + path2key(path=_value) FROM foreach(row=directories) })
+
+      // ["/home", "/var/log"] -> "^vrr_home$|^vrr_var_log$"
+      LET audit_keys_regex = join(
+        array=array(a={ SELECT "^" + path2key(path=_value) + "$"  FROM foreach(row=directories) }),
+        sep="|"
+       )
 
       LET isHidden(name) = if(
         condition=substr(str=name, start=0, end=1) = ".", then=true,
@@ -34,7 +42,7 @@ sources:
           basename(path=Paths[1].name) AS Filename,
           full_path(parent=Paths[0].name, name=Paths[1].name) AS Path
         FROM audit(rules=audit_rules)
-        WHERE "vrr_hidden_files" IN Tags
+        WHERE any(items=Tags, regex=audit_keys_regex)
           AND Result = "success"
           AND action =~ "opened-file|created-directory"
           AND Paths[1].nametype = "CREATE"

--- a/artifacts/definitions/SUSE/Linux/Events/UserAccount.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/UserAccount.yaml
@@ -9,7 +9,7 @@ type: CLIENT_EVENT
 sources:
 
   - query: |
-     LET user_acct_rules =  ("-w /etc/shadow -p wa -k vrr_etc_shadow", "-w /etc/passwd -p wa -k vrr_etc_modifications", "-w /etc/nsswitch.conf -p wa -k vrr_etc_nsswitch_conf")
+     LET user_acct_rules =  ("-w /etc/shadow -p wa -k vrr_etc_shadow", "-w /etc/passwd -p wa -k vrr_etc_passwd", "-w /etc/nsswitch.conf -p wa -k vrr_etc_nsswitch_conf")
 
      LET user_acct_log = SELECT timestamp(string=Timestamp) AS Time, Sequence,
            atoi(string=Process.PID) AS Pid,
@@ -18,7 +18,7 @@ sources:
            join(array=[Summary.action,Summary.object.type, Summary.object.primary], sep=" ") AS Action,
            Process.Title AS CmdLine
        FROM audit(rules=user_acct_rules)
-       WHERE "vrr_etc_modifications" in Tags OR "vrr_etc_nsswitch_conf" in Tags OR "vrr_etc_shadow" in Tags
+       WHERE "vrr_etc_passwd" in Tags OR "vrr_etc_nsswitch_conf" in Tags OR "vrr_etc_shadow" in Tags
 
      // Cache Uid -> Username mapping.
      LET usrs <= SELECT User, atoi(string=Uid) AS Uid


### PR DESCRIPTION
If more than one instance of the audit plugin is called with watch rules for the same path, but each using different keys, e.g.:
```
SELECT * FROM audit(rules=["-w /etc/passwd -k key1"]) WHERE "key1" IN Tags
SELECT * FROM audit(rules=["-w /etc/passwd -k key2"]) WHERE "key2" IN Tags
```
Then it turns out that any event will only be sent to one of the instances.

Fix by using the same key for the same paths across instances. The audit plugin reference counts audit rules and duplicates are not a problem.