### PR TITLE
Allow setting prevent_execve without breaking artifacts

### DIFF
--- a/actions/vql.go
+++ b/actions/vql.go
@@ -147,6 +147,7 @@ func (self VQLClientAction) StartQuery(
 
 	builder := services.ScopeBuilder{
 		Config: &config_proto.Config{
+			Client:		config_obj.Client,
 			Remappings: config_obj.Remappings,
 		},
 		// Only provide the client config since we are running in

--- a/vql/common/shell.go
+++ b/vql/common/shell.go
@@ -69,17 +69,17 @@ func (self ShellPlugin) Call(
 			return
 		}
 
-		// Check the config if we are allowed to execve at all.
-		config_obj, ok := artifacts.GetConfig(scope)
-		if ok && config_obj.PreventExecve {
-			scope.Log("shell: Not allowed to execve by configuration.")
-			return
-		}
-
 		arg := &ShellPluginArgs{}
 		err = arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 		if err != nil {
 			scope.Log("shell: %v", err)
+			return
+		}
+
+		// Check the config if we are allowed to execve at all.
+		config_obj, ok := artifacts.GetConfig(scope)
+		if ok && config_obj.PreventExecve && !alwaysAllow(arg) {
+			scope.Log("shell: Not allowed to execve by configuration.")
 			return
 		}
 
@@ -385,6 +385,20 @@ func defaultPipeReader(
 		}
 	}
 	return nil
+}
+
+// alwaysAllow returns true for execve calls required by artifacts.
+func alwaysAllow(args *ShellPluginArgs) bool {
+	if args.Env != nil || args.Cwd != "" || len(args.Argv) < 2 {
+		return false
+	}
+
+	switch strings.Join(args.Argv[:2], " ") {
+	case "systemctl show", "systemctl list-timers":
+		return true
+	}
+
+	return false
 }
 
 func init() {

--- a/vql/common/shell_test.go
+++ b/vql/common/shell_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+	"www.velocidex.com/golang/vfilter"
 )
 
 type ShellTestSuite struct {
@@ -93,6 +94,27 @@ func (self *ShellTestSuite) TestSplit() {
 	// Last line consists of the left over line before
 	assert.Equal(self.T(), []string{"part lineAnother"}, parts)
 	assert.Equal(self.T(), 4, offset)
+}
+
+func (self *ShellTestSuite) TestAlwaysAllow() {
+	testCases := []struct {
+		argv   []string
+		env    vfilter.LazyExpr
+		cwd    string
+		expect bool
+	}{
+		{[]string{"systemctl", "show", "apache"}, nil, "", true},
+		{[]string{"systemctl", "list-timers"}, nil, "", true},
+		{[]string{"systemctl", "stop", "firewalld"}, nil, "", false},
+		{[]string{"ls", "-l"}, nil, "", false},
+		{[]string{"systemctl", "show", "apache"}, nil, "/tmp", false},
+		{[]string{"systemctl", "show", "apache"}, &vfilter.LazyExprImpl{}, "", false},
+	}
+
+	for _, tc := range testCases {
+		args := &ShellPluginArgs{Argv: tc.argv, Env: tc.env, Cwd: tc.cwd}
+		assert.Equal(self.T(), tc.expect, alwaysAllow(args), "args: %+v, expected: %v", args, tc.expect)
+	}
 }
 
 func TestExecvePlugin(t *testing.T) {


### PR DESCRIPTION
A couple of artifacts depend on the execve plugin and won't work if prevent_execve is enabled. This patch makes exceptions for the two specific commands that are needed so execve will run them even if prevent_execve is enabled.

This patch also fixes CVE-2025-0914 by propagating the client config to queries.