### PR TITLE
Remove SHA1 file signatures

### DIFF
--- a/artifacts/definitions/Linux/Events/ProcessExecutions.yaml
+++ b/artifacts/definitions/Linux/Events/ProcessExecutions.yaml
@@ -30,7 +30,7 @@ sources:
        WHERE "vrr_procmon" in Tags AND Result = 'success'
 
      LET hash_log = SELECT *,
-           hash(path=Exe, hashselect=['SHA1', 'SHA256']) AS hashes
+           hash(path=Exe, hashselect=['SHA256']) AS hashes
        FROM exec_log
 
      // Cache Uid -> Username mapping.
@@ -42,7 +42,6 @@ sources:
               { SELECT User from users WHERE Uid = UserId} AS User,
               CmdLine,
               Exe, CWD,
-              hashes.SHA1 AS SHA1,
               hashes.SHA256 AS SHA256
        FROM hash_log
 
@@ -58,7 +57,7 @@ sources:
       LET exec_log = SELECT * FROM execsnoop()
 
       LET hash_log = SELECT *,
-          hash(path=Exe, hashselect=['SHA1', 'SHA256']) AS hashes
+          hash(path=Exe, hashselect=['SHA256']) AS hashes
         FROM exec_log
 
       // Cache Uid -> Username mapping.
@@ -70,6 +69,5 @@ sources:
         Argv AS CmdLine,
         Exe,
         Cwd AS CWD,
-        hashes.SHA1 AS SHA1,
         hashes.SHA256 AS SHA256
       FROM hash_log

--- a/artifacts/definitions/SUSE/Linux/Events/ExecutableFiles.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/ExecutableFiles.yaml
@@ -44,7 +44,7 @@ sources:
 
      LET hash_log = SELECT Time, UserId,
            State, FileName, FilePath,
-           hash(path=FilePath, hashselect=["SHA1", "SHA256"]) AS hashes
+           hash(path=FilePath, hashselect=["SHA256"]) AS hashes
        FROM exec_bit_log
        WHERE FilePath =~ directories_regex
 
@@ -57,6 +57,5 @@ sources:
      SELECT Time, UserId,
               get(item=uids_to_names, field=UserId).User AS User,
               State, FileName, FilePath,
-              hashes.SHA256 AS SHA256,
-              hashes.SHA1 AS SHA1
+              hashes.SHA256 AS SHA256
      FROM hash_log

--- a/artifacts/definitions/SUSE/Linux/Events/ImmutableFile.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/ImmutableFile.yaml
@@ -11,7 +11,7 @@ sources:
   - query: |
       LET events = SELECT
         *,
-        hash(path=Path, hashselect=["SHA1", "SHA256"]) as hashes
+        hash(path=Path, hashselect=["SHA256"]) as hashes
       FROM chattrsnoop()
 
       SELECT
@@ -19,6 +19,5 @@ sources:
         Path,
         Dir,
         Action,
-        hashes.SHA256 AS SHA256,
-        hashes.SHA1 AS SHA1
+        hashes.SHA256 AS SHA256
       FROM events

--- a/artifacts/definitions/SUSE/Linux/Events/NewFiles.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewFiles.yaml
@@ -30,11 +30,11 @@ sources:
      LET hash_log = SELECT Time, UserId,
            { SELECT User from usrs WHERE Uid = UserId} AS User,
            State, FileName, FilePath,
-           hash(path=FilePath, hashselect=['SHA1', 'SHA256']) AS Hash
+           hash(path=FilePath, hashselect=['SHA256']) AS Hash
        FROM new_file_log
 
      // Enrich the original artifact with more data.
      SELECT Time, UserId, User,
             State, FileName, FilePath, 
-            Hash.SHA256 AS Hash_SHA256, Hash.SHA1 AS Hash_SHA1
+            Hash.SHA256 AS SHA256
      FROM hash_log

--- a/artifacts/definitions/SUSE/Linux/Events/NewFilesNoOwner.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewFilesNoOwner.yaml
@@ -106,7 +106,7 @@ sources:
           AND NOT get(item=known_uids, field=UserID)
 
       LET fchown_events_with_hashes = SELECT *,
-          hash(path=FullPath, hashselect=['SHA1', 'SHA256']) AS hashes
+          hash(path=FullPath, hashselect=['SHA256']) AS hashes
         FROM fchown_events
 
       LET fchownat_events = SELECT
@@ -121,7 +121,7 @@ sources:
           AND NOT get(item=known_uids, field=UserID)
 
       LET fchownat_events_with_hashes = SELECT *,
-          hash(path=FullPath, hashselect=['SHA1', 'SHA256']) AS hashes
+          hash(path=FullPath, hashselect=['SHA256']) AS hashes
         FROM fchownat_events
 
       SELECT * FROM chain(
@@ -136,7 +136,6 @@ sources:
           SELECT
             FullPath,
             UserID,
-            hashes.SHA1 AS SHA1,
             hashes.SHA256 AS SHA256
           FROM fchown_events_with_hashes
         },
@@ -144,7 +143,6 @@ sources:
           SELECT
             FullPath,
             UserID,
-            hashes.SHA1 AS SHA1,
             hashes.SHA256 AS SHA256
           FROM fchownat_events_with_hashes
         }

--- a/artifacts/definitions/SUSE/Linux/Events/NewHiddenFile.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewHiddenFile.yaml
@@ -52,8 +52,8 @@ sources:
       LET new_hidden_files_with_hashes = SELECT *,
         { SELECT * FROM if(
             condition=action="opened-file",
-            then={ SELECT hash(path=Path, hashselect=['SHA1', 'SHA256']) FROM scope() },
-            else={ SELECT dict(SHA1=null, SHA256=null) FROM scope() })
+            then={ SELECT hash(path=Path, hashselect=['SHA256']) FROM scope() },
+            else={ SELECT dict(SHA256=null) FROM scope() })
         } AS hashes
         FROM hidden_files_events
 
@@ -61,7 +61,6 @@ sources:
         Time,
         Filename,
         Path,
-        hashes.SHA1 AS SHA1,
         hashes.SHA256 AS SHA256
       FROM new_hidden_files_with_hashes
 

--- a/artifacts/definitions/SUSE/Linux/Events/NewZeroSizeLogFile.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewZeroSizeLogFile.yaml
@@ -40,7 +40,7 @@ sources:
 
       LET zero_size_files_with_hashes = SELECT
           *,
-          hash(path=FilePath, hashselect=["SHA1", "SHA256"]) AS hashes
+          hash(path=FilePath, hashselect=["SHA256"]) AS hashes
       FROM zero_size_files
 
       SELECT
@@ -48,7 +48,6 @@ sources:
         Sequence,
         FileName,
         FilePath,
-        hashes.SHA1 AS SHA1,
         hashes.SHA256 AS SHA256
       FROM zero_size_files_with_hashes
 

--- a/artifacts/definitions/SUSE/Linux/Events/ProcessStatuses.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/ProcessStatuses.yaml
@@ -41,7 +41,7 @@ sources:
      SELECT Time, Pid, Ppid, UserId,
               { SELECT User from usrs WHERE Uid = UserId} AS User,
               State,CmdLine,
-              CWD, Exe AS ImagePath, Hash.SHA256 AS Hash_Sha256, Hash.SHA1 AS Hash_Sha1
+              CWD, Exe AS ImagePath, Hash.SHA256 AS SHA256
        FROM proc_exec_log
 
 
@@ -57,7 +57,7 @@ sources:
       LET exec_log = SELECT * FROM execsnoop() WHERE Uid != 0
 
       LET hash_log = SELECT *,
-          hash(path=Exe, hashselect=['SHA1', 'SHA256']) AS hashes
+          hash(path=Exe, hashselect=['SHA256']) AS hashes
         FROM exec_log
 
       // Cache Uid -> Username mapping.
@@ -71,6 +71,5 @@ sources:
         Argv AS CmdLine,
         Cwd AS CWD,
         Exe AS ImagePath,
-        hashes.SHA256 AS Hash_Sha256,
-        hashes.SHA1 AS Hash_Sha1
+        hashes.SHA256 AS SHA256
       FROM hash_log


### PR DESCRIPTION
The SHA256 is sufficient for Treat Intelligence identification. Also name the column consistenly as "SHA256".