### PR TITLE
Add machine-id to event artifacts

### DIFF
--- a/artifacts/definitions/Linux/Events/ProcessExecutions.yaml
+++ b/artifacts/definitions/Linux/Events/ProcessExecutions.yaml
@@ -16,6 +16,8 @@ sources:
         AND (version(plugin='execsnoop') = Null OR parse_float(string=parsed.kernel_ver) < 5.8)
 
     query: |
+     LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
      LET proc_exec_rules = ("-a always,exit -F arch=b64 -S execve -k vrr_procmon", "-a always,exit -F arch=b32 -S execve -k vrr_procmon")
 
      LET exec_log = SELECT timestamp(string=Timestamp) AS Time, Sequence,
@@ -38,7 +40,7 @@ sources:
        FROM Artifact.Linux.Sys.Users()
 
      // Enrich the original artifact with more data.
-     SELECT Time, Pid, Ppid, UserId,
+     SELECT Time, MachineID, Pid, Ppid, UserId,
               { SELECT User from users WHERE Uid = UserId} AS User,
               CmdLine,
               Exe, CWD,
@@ -55,6 +57,8 @@ sources:
         AND parse_float(string=parsed.kernel_ver) >= 5.8
 
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       LET exec_log = SELECT * FROM execsnoop()
 
       LET hash_log = SELECT *,
@@ -65,7 +69,7 @@ sources:
       LET users <= SELECT User, atoi(string=Uid) AS UserID
         FROM Artifact.Linux.Sys.Users()
 
-      SELECT Time, Pid, Ppid, Uid,
+      SELECT Time, MachineID, Pid, Ppid, Uid,
         { SELECT User from users WHERE UserID = Uid } AS User,
         Argv AS CmdLine,
         Exe,

--- a/artifacts/definitions/SUSE/Linux/Events/Cron.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/Cron.yaml
@@ -20,16 +20,21 @@ sources:
       SELECT OS From info() where OS = 'linux'
 
     query: |
-      SELECT * from cronsnoop(spool_dir='/var/spool/cron/tabs',system_dirs=['/etc/crontab', '/etc/cron.d', '/etc/cron.hourly', '/etc/cron.monthly', '/etc/cron.daily', '/etc/cron.weekly'])
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
+      SELECT MachineID, * from cronsnoop(spool_dir='/var/spool/cron/tabs',system_dirs=['/etc/crontab', '/etc/cron.d', '/etc/cron.hourly', '/etc/cron.monthly', '/etc/cron.daily', '/etc/cron.weekly'])
 
   - name: JournalTaskExecs
     precondition: SELECT OS From info() where OS = 'linux'
     description: Collect cron task executions from systemd journal
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       LET cron_exec = SELECT REALTIME_TIMESTAMP, _PID, MESSAGE, grok(grok=CronGrok, data=MESSAGE) AS Event
         FROM watch_journal()
         WHERE _TRANSPORT != 'kernel' AND SYSLOG_IDENTIFIER = "CRON" and Event.action = "CMD"
       SELECT timestamp(epoch=REALTIME_TIMESTAMP) AS Time,
+               MachineID,
                Event.user AS User,
                Event.cmd AS Cmd,
                _PID AS Pid,
@@ -40,11 +45,14 @@ sources:
     precondition: SELECT OS From info() where OS = 'linux'
     description: Collect cron task executions from syslog
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       -- Basic cron parsing via GROK expressions.
       LET cron_exec = SELECT grok(grok=CronGrok, data=Line) AS Event, Line
         FROM watch_syslog(filename=syslogCronLogPath)
         WHERE (Event.program = "CRON" OR Event.program = "cron") AND Event.action = "CMD"
       SELECT timestamp(string=Event.timestamp) AS Time,
+              MachineID,
               Event.user AS User,
               Event.cmd AS Cmd,
               Event.pid AS Pid,

--- a/artifacts/definitions/SUSE/Linux/Events/DNS.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/DNS.yaml
@@ -8,4 +8,6 @@ precondition: SELECT OS From info() where OS = 'linux'
 
 sources:
   - query: |
-      SELECT Timestamp, Type, Question, Answers FROM dnssnoop()
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
+      SELECT Timestamp, MachineID, Type, Question, Answers FROM dnssnoop()

--- a/artifacts/definitions/SUSE/Linux/Events/ExecutableFiles.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/ExecutableFiles.yaml
@@ -16,6 +16,8 @@ parameters:
 sources:
 
   - query: |
+     LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
      LET exec_bit_rules = ("-a always,exit -F arch=b64 -S fchmodat -F a2&73 -k vrr_exec_bit_addition", "-a always,exit -F arch=b32 -S fchmodat -F a2&73 -k vrr_exec_bit_addition", "-a always,exit -F arch=b64 -S fchmod -F a1&73 -k vrr_exec_bit_addition", "-a always,exit -F arch=b32 -S fchmod -F a1&73 -k vrr_exec_bit_addition")
 
      // ["/a", "/b", "/c"] -> "^/a|^/b|^/c"
@@ -54,7 +56,7 @@ sources:
        period=3600
      )
 
-     SELECT Time, UserId,
+     SELECT Time, MachineID, UserId,
               get(item=uids_to_names, field=UserId).User AS User,
               State, FileName, FilePath,
               hashes.SHA256 AS SHA256,

--- a/artifacts/definitions/SUSE/Linux/Events/ImmutableFile.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/ImmutableFile.yaml
@@ -9,6 +9,8 @@ precondition: SELECT OS From info() where OS = 'linux'
 
 sources:
   - query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       LET events = SELECT
         *,
         hash(path=Path, hashselect=["SHA1", "SHA256"]) as hashes
@@ -16,6 +18,7 @@ sources:
 
       SELECT
         Timestamp,
+        MachineID,
         Path,
         Dir,
         Action,

--- a/artifacts/definitions/SUSE/Linux/Events/NewFiles.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewFiles.yaml
@@ -12,6 +12,7 @@ required_permissions:
 
 sources:
   - query: |
+     LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
 
      LET new_file_rules = ("-w /etc/init.d -p wa -k vrr_etc_update", "-w /etc/rc.local -p wa -k vrr_etc_update", "-w /etc/modules -p wa -k vrr_etc_update", "-w /etc/cron.allow -p wa -k vrr_etc_update", "-w /etc/cron.deny -p wa -k vrr_etc_update", "-w /etc/cron.d/ -p wa -k vrr_etc_update", "-w /etc/cron.daily/ -p wa -k vrr_etc_update", "-w /etc/cron.hourly/ -p wa -k vrr_etc_update", "-w /etc/cron.monthly/ -p wa -k vrr_etc_update", "-w /etc/cron.weekly/ -p wa -k vrr_etc_update", "-w /etc/crontab -p wa -k vrr_etc_update", "-w /var/spool/cron -p wa -k vrr_etc_update")
 
@@ -34,7 +35,7 @@ sources:
        FROM new_file_log
 
      // Enrich the original artifact with more data.
-     SELECT Time, UserId, User,
+     SELECT Time, MachineID, UserId, User,
             State, FileName, FilePath, 
             Hash.SHA256 AS Hash_SHA256, Hash.SHA1 AS Hash_SHA1
      FROM hash_log

--- a/artifacts/definitions/SUSE/Linux/Events/NewFilesNoOwner.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewFilesNoOwner.yaml
@@ -16,6 +16,7 @@ parameters:
 
 sources:
   - query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
 
       // ["a", "b", "c"] -> "^a|^b|^c"
       LET directories_regex = join(
@@ -134,6 +135,7 @@ sources:
         },
         c={
           SELECT
+            MachineID,
             FullPath,
             UserID,
             hashes.SHA1 AS SHA1,
@@ -142,6 +144,7 @@ sources:
         },
         d={
           SELECT
+            MachineID,
             FullPath,
             UserID,
             hashes.SHA1 AS SHA1,

--- a/artifacts/definitions/SUSE/Linux/Events/NewHiddenFile.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewHiddenFile.yaml
@@ -16,6 +16,8 @@ parameters:
 
 sources:
   - query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       // function to make audit keys from paths e.g. /var/log/ -> vrr_var_log
       LET path2key(path) = "vrr_" + regex_replace(source=strip(string=path, prefix="/", suffix="/"), replace="_", re="/")
 
@@ -59,6 +61,7 @@ sources:
 
       SELECT
         Time,
+        MachineID,
         Filename,
         Path,
         hashes.SHA1 AS SHA1,

--- a/artifacts/definitions/SUSE/Linux/Events/NewZeroSizeLogFile.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/NewZeroSizeLogFile.yaml
@@ -9,6 +9,8 @@ type: CLIENT_EVENT
 
 sources:
   - query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       LET audit_rules = ("-w /var/log -p w -k vrr_var_log")
 
       // cleans path with relpath - see https://pkg.go.dev/path/filepath#Rel
@@ -45,6 +47,7 @@ sources:
 
       SELECT
         Time,
+        MachineID,
         Sequence,
         FileName,
         FilePath,

--- a/artifacts/definitions/SUSE/Linux/Events/ProcessStatuses.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/ProcessStatuses.yaml
@@ -16,6 +16,8 @@ sources:
         AND (version(plugin='execsnoop') = Null OR parse_float(string=parsed.kernel_ver) < 5.8)
 
     query: |
+     LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
      LET proc_stat_rules = ("-a always,exit -F arch=b64 -S execve -k vrr_procmon", "-a always,exit -F arch=b32 -S execve -k vrr_procmon")
 
      LET proc_exec_log = SELECT timestamp(string=Timestamp) AS Time, Sequence,
@@ -38,7 +40,7 @@ sources:
        FROM Artifact.Linux.Sys.Users()
 
      // Enrich the original artifact with more data.
-     SELECT Time, Pid, Ppid, UserId,
+     SELECT Time, MachineID, Pid, Ppid, UserId,
               { SELECT User from usrs WHERE Uid = UserId} AS User,
               State,CmdLine,
               CWD, Exe AS ImagePath, Hash.SHA256 AS Hash_Sha256, Hash.SHA1 AS Hash_Sha1
@@ -54,6 +56,8 @@ sources:
         AND parse_float(string=parsed.kernel_ver) >= 5.8
 
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       LET exec_log = SELECT * FROM execsnoop() WHERE Uid != 0
 
       LET hash_log = SELECT *,
@@ -64,7 +68,7 @@ sources:
       LET usrs <= SELECT User, atoi(string=Uid) AS UserID
         FROM Artifact.Linux.Sys.Users()
 
-      SELECT Time, Pid, Ppid,
+      SELECT Time, MachineID, Pid, Ppid,
         Uid AS UserID,
         { SELECT User from usrs WHERE UserID = Uid } AS User,
         "n/a" AS State,

--- a/artifacts/definitions/SUSE/Linux/Events/RPM.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/RPM.yaml
@@ -16,13 +16,14 @@ parameters:
 
 sources:
   - query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
 
       LET pkgFiles <= SELECT OSPath
                       FROM glob(root="/var/lib/rpm", globs=["Packages", "Packages.db", "rpmdb.sqlite"])
 
       -- Check the modification time of the packages file every period seconds,
       -- and only run the rpm plugin if the file has changed since the previous check.
-      SELECT * FROM foreach(
+      SELECT MachineID, * FROM foreach(
         row={
           SELECT * FROM foreach(
             row = {

--- a/artifacts/definitions/SUSE/Linux/Events/SSHLogin.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/SSHLogin.yaml
@@ -26,12 +26,15 @@ sources:
   - precondition: SELECT OS From info() where OS = 'linux'
     description: Collect successful SSH login attempts from syslog
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       -- Basic syslog parsing via GROK expressions.
       LET success_login = SELECT grok(grok=SSHGrok, data=Line) AS Event, Line
         FROM watch_syslog(filename=syslogAuthLogPath)
         WHERE Event.program = "sshd" AND Event.event = "Accepted"
 
       SELECT timestamp(string=Event.timestamp) AS Time,
+              MachineID,
               Event.user AS User,
               Event.method AS Method,
               Event.IP AS SourceIP,
@@ -44,10 +47,13 @@ sources:
   - precondition: SELECT OS From info() where OS = 'linux'
     description: Collect successful SSH login attempts from systemd journal
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       LET success_login = SELECT REALTIME_TIMESTAMP, _PID, MESSAGE, _SYSTEMD_UNIT, grok(grok=SSHGrok, data=MESSAGE) AS Event
         FROM watch_journal()
         WHERE _TRANSPORT != 'kernel' AND _SYSTEMD_UNIT = SSHSystemdUnit AND Event.event = "Accepted"
       SELECT timestamp(epoch=REALTIME_TIMESTAMP) AS Time,
+               MachineID,
                Event.user AS User,
                Event.method AS Method,
                Event.ip as SourceIP,

--- a/artifacts/definitions/SUSE/Linux/Events/Services.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/Services.yaml
@@ -13,6 +13,8 @@ type: CLIENT_EVENT
 
 sources:
   - query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       -- grok pattern to parse systemctl show output
       LET pattern = "%{NUMBER:pid}\n\{ path\=%{DATA:process} .*\n%{DATA:description}\n%{DATA:state}\n"
 
@@ -37,6 +39,7 @@ sources:
 
       SELECT
         Timestamp,
+        MachineID,
         Service,
         "root" AS User,
         details.pid AS PID,

--- a/artifacts/definitions/SUSE/Linux/Events/SshAuthorizedKeys.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/SshAuthorizedKeys.yaml
@@ -17,8 +17,14 @@ parameters:
 
 sources:
   - query: |
-      SELECT Mtime AS Timestamp, User, Uid, OSPath AS Path, Diff AS Change, Key, Comment FROM diff(
-        query={ SELECT *, join(array=[User, Key]) AS _diffKey FROM Artifact.Linux.Ssh.AuthorizedKeys() },
-        key="_diffKey",
-        period=period)
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
 
+      SELECT Mtime AS Timestamp, MachineID, User, Uid, OSPath AS Path, Diff AS Change, Key, Comment
+      FROM diff(
+        query={
+          SELECT *, join(array=[User, Key]) AS _diffKey
+          FROM Artifact.Linux.Ssh.AuthorizedKeys()
+        },
+        key="_diffKey",
+        period=period
+      )

--- a/artifacts/definitions/SUSE/Linux/Events/SystemLogins.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/SystemLogins.yaml
@@ -10,24 +10,27 @@ sources:
       SELECT OS From info() where OS = 'linux'
 
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
       LET SYSTEM_LOGINS = SELECT Timestamp, Sequence, Result, Session, str(str=Category) as auth_category, str(str=Type) as auth_type, Data.acct as Account, Data.op as Method, Data.addr as Source_IP, Data.hostname as Source_Hostname, Data.terminal as Terminal FROM audit() WHERE auth_category = 'user-login' AND auth_type = 'USER_AUTH' AND Result = 'success'
-      SELECT * FROM foreach(row=SYSTEM_LOGINS, query={SELECT Timestamp, Sequence, Result, Session, Method, Account as User, Source_IP, Source_Hostname, Terminal FROM scope()})
+      SELECT MachineID, * FROM foreach(row=SYSTEM_LOGINS, query={SELECT Timestamp, Sequence, Result, Session, Method, Account as User, Source_IP, Source_Hostname, Terminal FROM scope()})
 
   - name: FailedLogins
     precondition:
       SELECT OS From info() where OS = 'linux'
 
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
       LET SYSTEM_LOGINS = SELECT Timestamp, Sequence, Result, Session, str(str=Category) as auth_category, str(str=Type) as auth_type, Data.acct as Account, Data.op as Method, Data.addr as Source_IP, Data.hostname as Source_Hostname, Data.terminal as Terminal FROM audit() WHERE auth_category = 'user-login' AND auth_type = 'USER_AUTH' AND Result = 'fail'
-      SELECT * FROM foreach(row=SYSTEM_LOGINS, query={SELECT Timestamp, Sequence, Result, Session, Method, Account as User, Source_IP, Source_Hostname, Terminal FROM scope()})
+      SELECT MachineID, * FROM foreach(row=SYSTEM_LOGINS, query={SELECT Timestamp, Sequence, Result, Session, Method, Account as User, Source_IP, Source_Hostname, Terminal FROM scope()})
 
   - name: SuccessfulLogouts
     precondition:
       SELECT OS From info() where OS = 'linux'
 
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
       LET SYSTEM_LOGINS = SELECT Timestamp, Sequence, Result, Session, str(str=Category) as auth_category, str(str=Type) as auth_type, Data.acct as Account, Data.op as Method, Data.addr as Source_IP, Data.hostname as Source_Hostname, Data.terminal as Terminal FROM audit() WHERE auth_category = 'user-login' AND auth_type = 'USER_END' AND Result = 'success' AND Method != 'login'
-      SELECT * FROM foreach(row=SYSTEM_LOGINS, query={SELECT Timestamp, Sequence, Result, Session, Method, Account as User, Source_IP, Source_Hostname, Terminal FROM scope()})
+      SELECT MachineID, * FROM foreach(row=SYSTEM_LOGINS, query={SELECT Timestamp, Sequence, Result, Session, Method, Account as User, Source_IP, Source_Hostname, Terminal FROM scope()})
 
 reports:
   - type: MONITORING_DAILY

--- a/artifacts/definitions/SUSE/Linux/Events/TCPConnections.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/TCPConnections.yaml
@@ -8,5 +8,7 @@ precondition: SELECT OS From info() where OS = 'linux'
 
 sources:
   - query: |
-      SELECT Timestamp, RemoteAddr, LocalAddr, Task, Af, Pid, Uid,
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
+      SELECT Timestamp, MachineID, RemoteAddr, LocalAddr, Task, Af, Pid, Uid,
              RemotePort, LocalPort, Dir FROM tcpsnoop()

--- a/artifacts/definitions/SUSE/Linux/Events/Timers.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/Timers.yaml
@@ -9,7 +9,10 @@ sources:
     precondition: SELECT OS From info() where OS = 'linux'
     description: Collect event when a new timer is started or stopped
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       SELECT timestamp(string=REALTIME_TIMESTAMP) as Time,
+              MachineID,
               JOB_TYPE AS Action,
               UNIT As Timer
         FROM watch_journal()
@@ -19,12 +22,15 @@ sources:
     precondition: SELECT OS From info() where OS = 'linux'
     description: Collect systemd timer executions from journal
     query: |
+      LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
       LET timers = SELECT parse_json_array(data=Stdout) AS list
         FROM execve(argv=['systemctl', 'list-timers', '--all', '-o', 'json', '--no-pager'])
 
       LET timer_execs = SELECT *, {SELECT activates from timers.list} AS activates
         FROM Artifact.SUSE.Linux.Events.Services()
-        WHERE format(format="%s%s" , args=[Service, ".service"]) in activates
+        WHERE Service in activates
+          OR format(format="%s%s" , args=[Service, ".service"]) in activates
 
-      SELECT Timestamp, PID, User, Process as Cmd, Description
+      SELECT Timestamp, MachineID, PID, User, Process as Cmd, Description
         FROM timer_execs

--- a/artifacts/definitions/SUSE/Linux/Events/UserAccount.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/UserAccount.yaml
@@ -9,6 +9,8 @@ type: CLIENT_EVENT
 sources:
 
   - query: |
+     LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
+
      LET user_acct_rules =  ("-w /etc/shadow -p wa -k vrr_etc_shadow", "-w /etc/passwd -p wa -k vrr_etc_passwd", "-w /etc/nsswitch.conf -p wa -k vrr_etc_nsswitch_conf")
 
      LET user_acct_log = SELECT timestamp(string=Timestamp) AS Time, Sequence,
@@ -25,7 +27,7 @@ sources:
        FROM Artifact.Linux.Sys.Users()
 
      // Enrich the original artifact with more data.
-     SELECT Time, UserId,
+     SELECT Time, MachineID, UserId,
               { SELECT User from usrs WHERE Uid = UserId} AS User,
               State, Action, CmdLine
      FROM user_acct_log

--- a/artifacts/definitions/SUSE/Linux/Events/UserGroupMembershipUpdates.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/UserGroupMembershipUpdates.yaml
@@ -12,6 +12,7 @@ required_permissions:
 
 sources:
   - query: |
+     LET MachineID <= strip(string=read_file(filename="/etc/machine-id"), suffix="\n")
 
      LET change_log_rules = ("-w /etc/group -p wa -k vrr_etc_group", "-w /etc/nsswitch.conf -p wa -k vrr_etc_nsswitch_conf")
 
@@ -29,7 +30,7 @@ sources:
        FROM Artifact.Linux.Sys.Users()
 
      // Enrich the original artifact with more data.
-     SELECT Time, UserId,
+     SELECT Time, MachineID, UserId,
             { SELECT User from usrs WHERE Uid = UserId} AS User,
             State, CmdLine, Exe, CWD
      FROM change_log


### PR DESCRIPTION
Updates each event query to include the machine-id for SENS-149. A materialized call is used to read /etc/machine-id, so it's only done once per query.