### PR TITLE
Fix symbol not found errors from SUSE.Linux.Events.Services

### DIFF
--- a/artifacts/definitions/SUSE/Linux/Events/Services.yaml
+++ b/artifacts/definitions/SUSE/Linux/Events/Services.yaml
@@ -19,7 +19,7 @@ sources:
       LET pattern = "%{NUMBER:pid}\n\{ path\=%{DATA:process} .*\n%{DATA:description}\n%{DATA:state}\n"
 
       -- local function runs systemctl, parses output and deconstructs dict from grok
-      LET serviceDetails(name) = SELECT pid, process, description, state
+      LET serviceDetails(name) = SELECT *
         FROM foreach(
           row= { SELECT grok(data=stdout, grok=pattern) AS parsed
                  FROM execve(argv=["systemctl", "show", name, "--value", "--property=ExecMainPID,ExecStart,Description,ActiveState"]) },


### PR DESCRIPTION
Sometimes grok() fails to parse the output of systemctl and the logs get spammed with "symbol not found in scope" error messages.

Fix by not referencing the expected symbols in the serviceDetails() function as there is no need. They are referenced from a dict in the main SELECT and get the value of null if they don't exist without any error messages.